### PR TITLE
passwdsafe: Use AES CTR mode for in-memory passwords

### DIFF
--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsFile.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsFile.java
@@ -138,7 +138,7 @@ public abstract class PwsFile
     /**
      * Cipher spec for storing passwords in memory
      */
-    private static final String CIPHER_SPEC = "AES/CBC/PKCS5Padding";
+    private static final String CIPHER_SPEC = "AES/CTR/NoPadding";
 
     /**
      * Cipher key spec for storing passwords in memory


### PR DESCRIPTION
Fixes #6