### PR TITLE
passwdsafe: Always show the share action in record list menu

### DIFF
--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2024 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -478,13 +478,11 @@ public class PasswdSafe extends AppCompatActivity
         itsFileDataFrag.useFileData((PasswdFileDataUser<Void>)fileData -> {
             boolean fileCanRestore = false;
             boolean fileCanRestoreEnabled = false;
-            boolean fileCanShare = false;
             switch (fileData.getUri().getType()) {
             case BACKUP: {
                 BackupFile backup = fileData.getUri().getBackupFile();
                 fileCanRestore = true;
                 fileCanRestoreEnabled = (backup != null) && backup.hasUriPerm;
-                fileCanShare = true;
                 break;
             }
             case FILE:
@@ -500,12 +498,12 @@ public class PasswdSafe extends AppCompatActivity
             case VIEW_LIST: {
                 options.set(MENU_BIT_CAN_ADD, fileEditable);
                 options.set(MENU_BIT_HAS_SEARCH, true);
+                options.set(MENU_BIT_HAS_SHARE, true);
                 if (fileEditable) {
                     options.set(MENU_BIT_HAS_FILE_OPS, true);
                     options.set(MENU_BIT_HAS_FILE_CHANGE_PASSWORD,
                                 fileData.isNotYubikey());
                     options.set(MENU_BIT_HAS_FILE_PROTECT, true);
-                    fileCanShare = true;
                     options.set(MENU_BIT_PROTECT_ALL,
                                 itsLocation.getGroups().isEmpty());
                 }
@@ -513,7 +511,6 @@ public class PasswdSafe extends AppCompatActivity
                     options.set(MENU_BIT_HAS_FILE_OPS, true);
                     options.set(MENU_BIT_HAS_FILE_DELETE, true);
                 }
-                options.set(MENU_BIT_HAS_SHARE, fileCanShare);
                 options.set(MENU_BIT_HAS_RESTORE, fileCanRestore);
                 options.set(MENU_BIT_HAS_RESTORE_ENABLED,
                             fileCanRestoreEnabled);

--- a/passwdsafe/src/main/res/menu/activity_passwdsafe.xml
+++ b/passwdsafe/src/main/res/menu/activity_passwdsafe.xml
@@ -1,26 +1,29 @@
 <!--
-  ~ Copyright (©) 2016 Jeff Harris <jefftharris@gmail.com>
+  ~ Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
   ~ All rights reserved. Use of the code is allowed under the
   ~ Artistic License 2.0 terms, as specified in the LICENSE file
   ~ distributed with this code, or available from
   ~ http://www.opensource.org/licenses/artistic-license-2.0.php
   -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context=".PasswdSafe">
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".PasswdSafe">
 
-    <item android:id="@+id/menu_search"
-          android:title="@string/search"
-          android:icon="@drawable/ic_action_search"
-          app:showAsAction="ifRoom|collapseActionView"
-          app:actionViewClass="androidx.appcompat.widget.SearchView" />
+    <item
+        android:id="@+id/menu_search"
+        android:icon="@drawable/ic_action_search"
+        android:title="@string/search"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="ifRoom|collapseActionView"/>
 
-    <item android:id="@+id/menu_add"
-          android:title="@string/add_record"
-          android:icon="@drawable/ic_action_add"
-          android:orderInCategory="100"
-          app:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/menu_add"
+        android:icon="@drawable/ic_action_add"
+        android:orderInCategory="100"
+        android:title="@string/add_record"
+        app:showAsAction="ifRoom"/>
 
     <item
         android:id="@+id/menu_restore"
@@ -28,35 +31,41 @@
         android:title="@string/restore"
         app:showAsAction="ifRoom"/>
 
-    <item android:id="@+id/menu_file_ops"
-          android:title="@string/file_operations"
-          android:orderInCategory="100">
+    <item
+        android:id="@+id/menu_file_ops"
+        android:orderInCategory="100"
+        android:title="@string/file_operations">
         <menu>
-            <item android:id="@+id/menu_file_change_password"
-                  android:title="@string/change_password"/>
+            <item
+                android:id="@+id/menu_file_change_password"
+                android:title="@string/change_password"/>
 
-            <item android:id="@+id/menu_file_protect_records"
-                  android:title="@string/protect_all"/>
+            <item
+                android:id="@+id/menu_file_protect_records"
+                android:title="@string/protect_all"/>
 
-            <item android:id="@+id/menu_file_unprotect_records"
-                  android:title="@string/unprotect_all"/>
+            <item
+                android:id="@+id/menu_file_unprotect_records"
+                android:title="@string/unprotect_all"/>
 
-            <item android:id="@+id/menu_file_delete"
-                  android:title="@string/delete_file"/>
+            <item
+                android:id="@+id/menu_file_delete"
+                android:title="@string/delete_file"/>
         </menu>
     </item>
 
     <item
         android:id="@+id/menu_share"
-        android:title="@string/share_file"
         android:icon="@drawable/ic_action_share_light"
         android:orderInCategory="1000"
+        android:title="@string/share_file"
         app:showAsAction="ifRoom"/>
 
-    <item android:id="@+id/menu_close"
-          android:title="@string/close_file"
-          android:icon="@drawable/ic_action_close_cancel"
-          android:orderInCategory="1000"
-          app:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/menu_close"
+        android:icon="@drawable/ic_action_close_cancel"
+        android:orderInCategory="1000"
+        android:title="@string/close_file"
+        app:showAsAction="ifRoom"/>
 
 </menu>

--- a/passwdsafe/src/main/res/menu/activity_passwdsafe.xml
+++ b/passwdsafe/src/main/res/menu/activity_passwdsafe.xml
@@ -34,7 +34,8 @@
     <item
         android:id="@+id/menu_file_ops"
         android:orderInCategory="100"
-        android:title="@string/file_operations">
+        android:title="@string/file_operations"
+        app:showAsAction="never">
         <menu>
             <item
                 android:id="@+id/menu_file_change_password"
@@ -57,9 +58,9 @@
     <item
         android:id="@+id/menu_share"
         android:icon="@drawable/ic_action_share_light"
-        android:orderInCategory="1000"
+        android:orderInCategory="100"
         android:title="@string/share_file"
-        app:showAsAction="ifRoom"/>
+        app:showAsAction="never"/>
 
     <item
         android:id="@+id/menu_close"

--- a/passwdsafe/src/main/res/menu/fragment_passwdsafe_list.xml
+++ b/passwdsafe/src/main/res/menu/fragment_passwdsafe_list.xml
@@ -1,20 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (©) 2016 Jeff Harris <jefftharris@gmail.com>
+  ~ Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
   ~ All rights reserved. Use of the code is allowed under the
   ~ Artistic License 2.0 terms, as specified in the LICENSE file
   ~ distributed with this code, or available from
   ~ http://www.opensource.org/licenses/artistic-license-2.0.php
   -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context=".PasswdSafeListFragment">
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".PasswdSafeListFragment">
 
-    <item android:id="@+id/menu_sort"
-          android:title="@string/sort"
-          android:icon="@drawable/ic_action_content_sort"
-          android:orderInCategory="100"
-          app:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/menu_sort"
+        android:icon="@drawable/ic_action_content_sort"
+        android:orderInCategory="100"
+        android:title="@string/sort"
+        app:showAsAction="ifRoom"/>
 
 </menu>

--- a/passwdsafe/src/main/res/menu/fragment_passwdsafe_list.xml
+++ b/passwdsafe/src/main/res/menu/fragment_passwdsafe_list.xml
@@ -16,6 +16,6 @@
         android:icon="@drawable/ic_action_content_sort"
         android:orderInCategory="100"
         android:title="@string/sort"
-        app:showAsAction="ifRoom"/>
+        app:showAsAction="never"/>
 
 </menu>


### PR DESCRIPTION
When viewing the list, always show the action item.  Mark it and others
as never showing as actions so the trailing close item is visible as
before.  Move the sort item into the menu always.

Resolves #17