### PR TITLE
passwdsafe: GH-23 Add option to display on external monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /.idea/assetWizardSettings.xml
 /.idea/deploymentTargetDropDown.xml
 /.idea/deploymentTargetSelector.xml
+/.idea/emulatorDisplays.xml
 /.idea/workspace.xml
 /.idea/caches/
 /.idea/libraries/

--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,8 +1,10 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0" is_locked="false">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="AndroidLintEasterEgg" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AndroidLintIconExpectedSize" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AndroidLintNegativeMargin" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="AndroidLintNoOp" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="AndroidLintUnsupportedChromeOsHardware" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="AndroidLintUnusedIds" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ClangTidy" enabled="true" level="WARNING" enabled_by_default="true">
@@ -14,11 +16,14 @@
       <option name="ignoreSwitchStatementsWithDefault" value="false" />
     </inspection_tool>
     <inspection_tool class="FallthruInSwitchStatement" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="GroovyNonShortCircuitBoolean" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="GroovyRangeTypeCheck" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ImplicitNumericConversion" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreWideningConversions" value="true" />
       <option name="ignoreCharConversions" value="false" />
       <option name="ignoreConstantConversions" value="false" />
     </inspection_tool>
+    <inspection_tool class="InconsistentLineSeparators" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="OctalAndDecimalIntegersMixed" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PointlessArithmeticExpression" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_ignoreExpressionsContainingConstants" value="true" />

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.8.2'
+        classpath 'com.android.tools.build:gradle:8.9.0'
 
         // From https://github.com/google/secrets-gradle-plugin
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/lib/src/main/java/com/jefftharris/passwdsafe/lib/ApiCompat.java
+++ b/lib/src/main/java/com/jefftharris/passwdsafe/lib/ApiCompat.java
@@ -104,6 +104,15 @@ public final class ApiCompat
 
 
     /**
+     * Are external displays supported
+     */
+    public static boolean supportsExternalDisplays()
+    {
+        return SDK_VERSION >= SDK_R;
+    }
+
+
+    /**
      * Are the external files directories supported
      */
     public static boolean supportsExternalFilesDirs()

--- a/lib/src/main/java/com/jefftharris/passwdsafe/lib/ApiCompat.java
+++ b/lib/src/main/java/com/jefftharris/passwdsafe/lib/ApiCompat.java
@@ -8,6 +8,7 @@
 package com.jefftharris.passwdsafe.lib;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.ClipData;
@@ -19,7 +20,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.Vibrator;
-import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import androidx.annotation.ChecksSdkIntAtLeast;
@@ -77,11 +77,21 @@ public final class ApiCompat
     }
 
 
-    /** Set whether the window is visible in the recent apps list */
-    public static void setRecentAppsVisible(
-            Window w, @SuppressWarnings("SameParameterValue") boolean visible)
+    /**
+     * Protect the window from being shown in the recent apps and from
+     * screenshots
+     */
+    public static void protectDisplay(Activity act,
+                                      boolean showUntrustedExternal)
     {
-        if (visible) {
+        boolean setRecentVisible = false;
+        if (supportsExternalDisplays()) {
+            setRecentVisible = showUntrustedExternal &&
+                               ApiCompatR.isOnExternalDisplay(act);
+        }
+
+        var w = act.getWindow();
+        if (setRecentVisible) {
             w.clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
         } else {
             w.addFlags(WindowManager.LayoutParams.FLAG_SECURE);

--- a/lib/src/main/java/com/jefftharris/passwdsafe/lib/ApiCompatR.java
+++ b/lib/src/main/java/com/jefftharris/passwdsafe/lib/ApiCompatR.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (©) 2025 Jeff Harris <jefftharris@gmail.com>
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+package com.jefftharris.passwdsafe.lib;
+
+import android.app.Activity;
+import android.os.Build;
+import android.view.Display;
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+/**
+ * The ApiCompatR class contains helper methods that are usable on
+ * R and higher
+ */
+@RequiresApi(Build.VERSION_CODES.R)
+public final class ApiCompatR
+{
+    /**
+     * Is the activity being shown on an external display
+     */
+    public static boolean isOnExternalDisplay(@NonNull Activity act)
+    {
+        var display = act.getDisplay();
+        return (display != null) && (display.getDisplayId() !=
+                                     Display.DEFAULT_DISPLAY);
+    }
+}

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
@@ -19,7 +19,6 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
-import android.view.Display;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -1320,19 +1319,9 @@ public class PasswdSafe extends AppCompatActivity
      */
     private void protectDisplay()
     {
-        boolean setRecentVisible = false;
-        if (ApiCompat.supportsExternalDisplays()) {
-            var prefs = Preferences.getSharedPrefs(this);
-            if (Preferences.isDisplayShowUntrustedExternal(prefs)) {
-                var display = getDisplay();
-                if ((display != null) &&
-                    (display.getDisplayId() != Display.DEFAULT_DISPLAY)) {
-                    setRecentVisible = true;
-                }
-            }
-        }
-
-        ApiCompat.setRecentAppsVisible(getWindow(), setRecentVisible);
+        var prefs = Preferences.getSharedPrefs(this);
+        ApiCompat.protectDisplay(
+                this, Preferences.isDisplayShowUntrustedExternal(prefs));
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
@@ -19,6 +19,7 @@ import android.os.Bundle;
 import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.Display;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -282,7 +283,8 @@ public class PasswdSafe extends AppCompatActivity
         PasswdSafeApp.setupTheme(this);
         EdgeToEdge.enable(this);
         super.onCreate(savedInstanceState);
-        ApiCompat.setRecentAppsVisible(getWindow(), false);
+        protectDisplay();
+
         setContentView(R.layout.activity_passwdsafe);
         itsIsTwoPane = (findViewById(R.id.two_pane) != null);
 
@@ -1310,6 +1312,27 @@ public class PasswdSafe extends AppCompatActivity
     @Override
     public void promptCanceled()
     {
+    }
+
+    /**
+     * Protect the window from being shown in the recent apps and from
+     * screenshots
+     */
+    private void protectDisplay()
+    {
+        boolean setRecentVisible = false;
+        if (ApiCompat.supportsExternalDisplays()) {
+            var prefs = Preferences.getSharedPrefs(this);
+            if (Preferences.isDisplayShowUntrustedExternal(prefs)) {
+                var display = getDisplay();
+                if ((display != null) &&
+                    (display.getDisplayId() != Display.DEFAULT_DISPLAY)) {
+                    setRecentVisible = true;
+                }
+            }
+        }
+
+        ApiCompat.setRecentAppsVisible(getWindow(), setRecentVisible);
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/Preferences.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/Preferences.java
@@ -132,6 +132,11 @@ public class Preferences
             "displayVibrateKeyboard";
     private static final boolean PREF_DISPLAY_VIBRATE_KEYBOARD_DEF = false;
 
+    public static final String PREF_DISPLAY_SHOW_UNTRUSTED_EXTERNAL =
+            "displayShowUntrustedExternal";
+    private static final boolean PREF_DISPLAY_SHOW_UNTRUSTED_EXTERNAL_DEF =
+            false;
+
     private static final String PREF_COPY_PASSWORD_CONFIRM =
             "copyPasswordConfirm";
     private static final boolean PREF_COPY_PASSWORD_CONFIRM_DEF = false;
@@ -468,6 +473,17 @@ public class Preferences
     {
         return prefs.getBoolean(PREF_DISPLAY_VIBRATE_KEYBOARD,
                                 PREF_DISPLAY_VIBRATE_KEYBOARD_DEF);
+    }
+
+
+    /**
+     * Get whether to show the main screen on untrusted external displays
+     */
+    public static boolean isDisplayShowUntrustedExternal(
+            @NonNull SharedPreferences prefs)
+    {
+        return prefs.getBoolean(PREF_DISPLAY_SHOW_UNTRUSTED_EXTERNAL,
+                                PREF_DISPLAY_SHOW_UNTRUSTED_EXTERNAL_DEF);
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PreferencesFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PreferencesFragment.java
@@ -250,6 +250,12 @@ public class PreferencesFragment extends PreferenceFragmentCompat
                 pref.setVisible(ApiCompat.hasVibrator(requireContext()));
             }
 
+            pref = findPreference(
+                    Preferences.PREF_DISPLAY_SHOW_UNTRUSTED_EXTERNAL);
+            if (pref != null) {
+                pref.setVisible(ApiCompat.supportsExternalDisplays());
+            }
+
             itsDebugTagsPref = requirePreference(Preferences.PREF_DEBUG_TAGS);
             itsDebugTagsPref.setDialogMessage(R.string.logging_tags_desc);
             itsDebugTagsPref.setDefaultValue(Preferences.PREF_DEBUG_TAGS_DEF);

--- a/passwdsafe/src/main/res/values/strings.xml
+++ b/passwdsafe/src/main/res/values/strings.xml
@@ -373,7 +373,7 @@
     <string name="shortcut_record">Shortcut record</string>
     <string name="shortcut_to_same_record">Shortcut to the same record</string>
     <string name="show_backup_files">Show backup files</string>
-    <string name="show_on_untrusted_external_displays">Show on untrusted external displays</string>
+    <string name="show_on_untrusted_external_displays" tools:ignore="MissingTranslation">Show on untrusted external displays</string>
     <string name="show_password">Show Password</string>
     <string name="show_passwords">Show Passwords</string>
     <string name="similar_to">Similar to %1$s</string>

--- a/passwdsafe/src/main/res/values/strings.xml
+++ b/passwdsafe/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (©) 2016 Jeff Harris <jefftharris@gmail.com>
+  ~ Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
   ~ All rights reserved. Use of the code is allowed under the
   ~ Artistic License 2.0 terms, as specified in the LICENSE file
   ~ distributed with this code, or available from
@@ -373,6 +373,7 @@
     <string name="shortcut_record">Shortcut record</string>
     <string name="shortcut_to_same_record">Shortcut to the same record</string>
     <string name="show_backup_files">Show backup files</string>
+    <string name="show_on_untrusted_external_displays">Show on untrusted external displays</string>
     <string name="show_password">Show Password</string>
     <string name="show_passwords">Show Passwords</string>
     <string name="similar_to">Similar to %1$s</string>

--- a/passwdsafe/src/main/res/xml/preferences.xml
+++ b/passwdsafe/src/main/res/xml/preferences.xml
@@ -156,6 +156,12 @@
             android:title="@string/theme"/>
 
         <com.jefftharris.passwdsafe.lib.view.LongSwitchPreference
+            android:name="displayShowUntrustedExternal Pref"
+            android:defaultValue="false"
+            android:key="displayShowUntrustedExternal"
+            android:title="@string/show_on_untrusted_external_displays"/>
+
+        <com.jefftharris.passwdsafe.lib.view.LongSwitchPreference
             android:name="displayVibrateKeyboard Pref"
             android:defaultValue="false"
             android:key="displayVibrateKeyboard"

--- a/passwdsafe/src/main/res/xml/preferences.xml
+++ b/passwdsafe/src/main/res/xml/preferences.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (©) 2016 Jeff Harris <jefftharris@gmail.com>
+  ~ Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
   ~ All rights reserved. Use of the code is allowed under the
   ~ Artistic License 2.0 terms, as specified in the LICENSE file
   ~ distributed with this code, or available from
@@ -12,52 +12,45 @@
     <PreferenceScreen android:key="fileOptions"
                       android:title="@string/files">
         <PreferenceCategory android:title="@string/files">
-            <!--suppress AndroidElementNotAllowed -->
+
             <com.jefftharris.passwdsafe.lib.view.LongEditTextPreference
                 android:name="FileDir Pref"
                 android:key="fileDirPref"
                 android:title="@string/directory_for_files"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongPreference
                 android:name="defaultFile Pref"
                 android:key="defFilePref"
                 android:title="@string/default_file_to_open"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongListPreference
                 android:name="fileTimeout Pref"
                 android:key="fileCloseTimeoutPref"
                 android:title="@string/file_close_timeout"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongCheckBoxPreference
                 android:name="fileCloseScreenOff Pref"
                 android:defaultValue="false"
                 android:key="fileCloseScreenOffPref"
                 android:title="@string/close_file_screen_off"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongListPreference
                 android:name="fileBackup Pref"
                 android:key="fileBackupPref"
                 android:title="@string/file_backups"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongCheckBoxPreference
                 android:name="showBackupFiles Pref"
                 android:defaultValue="false"
                 android:key="showBackupFilesPref"
                 android:title="@string/show_backup_files"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongCheckBoxPreference
                 android:name="fileCloseClearClipboard Pref"
                 android:defaultValue="true"
                 android:key="fileCloseClearClipboardPref"
                 android:title="@string/clear_clipboard_on_close"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongCheckBoxPreference
                 android:name="fileLegacyFileChooser Pref"
                 android:defaultValue="true"
@@ -71,36 +64,30 @@
                       android:title="@string/passwords">
         <PreferenceCategory android:title="@string/passwords">
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongListPreference
                 android:name="passwordVisibleTimeout Pref"
                 android:key="passwordVisibleTimeoutPref"
                 android:title="@string/password_visibility_timeout"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongListPreference
                 android:name="passwordEncoding Pref"
                 android:key="passwordEncodingPref"
                 android:title="@string/file_password_encoding"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongListPreference
                 android:name="passwordExpiryNotify Pref"
                 android:key="passwordExpiryNotifyPref"
                 android:title="@string/expired_password_notification"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.lib.view.LongEditTextPreference
                 android:key="passwordDefaultSymbolsPref"
                 android:title="@string/default_symbols"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongPreference
                 android:key="passwordClearAllNotifsPref"
                 android:summary="@string/erase_all_expiration_notifications"
                 android:title="@string/clear_password_notifications"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongPreference
                 android:key="passwordClearAllSavedPref"
                 android:summary="@string/erase_all_saved_passwords"
@@ -112,34 +99,29 @@
                       android:title="@string/records">
         <PreferenceCategory android:title="@string/records">
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongCheckBoxPreference
                 android:name="sortCaseSensitive Pref"
                 android:defaultValue="true"
                 android:key="sortCaseSensitivePref"
                 android:title="@string/case_sensitive_sorting"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongCheckBoxPreference
                 android:name="sortAscending Pref"
                 android:defaultValue="true"
                 android:key="sortAscendingPref"
                 android:title="@string/sort_ascending"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongCheckBoxPreference
                 android:name="groupRecords Pref"
                 android:defaultValue="true"
                 android:key="groupRecordsPref"
                 android:title="@string/group_records"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongListPreference
                 android:name="recordSortOrder Pref"
                 android:key="recordSortOrderPref"
                 android:title="@string/record_sort_order"/>
 
-            <!--suppress AndroidElementNotAllowed -->
             <com.jefftharris.passwdsafe.view.LongListPreference
                 android:name="recordFieldSortPref"
                 android:key="recordFieldSortPref"
@@ -150,14 +132,12 @@
     <PreferenceCategory android:key="searchOptions"
                         android:title="@string/search">
 
-        <!--suppress AndroidElementNotAllowed -->
         <com.jefftharris.passwdsafe.view.LongCheckBoxPreference
             android:name="searchCaseSensitive Pref"
             android:defaultValue="false"
             android:key="searchCaseSensitivePref"
             android:title="@string/case_sensitive"/>
 
-        <!--suppress AndroidElementNotAllowed -->
         <com.jefftharris.passwdsafe.view.LongCheckBoxPreference
             android:name="searchRegex Pref"
             android:defaultValue="false"
@@ -170,13 +150,11 @@
     <PreferenceCategory android:key="displayOptions"
                         android:title="@string/display">
 
-        <!--suppress AndroidElementNotAllowed -->
         <com.jefftharris.passwdsafe.view.LongListPreference
             android:name="displayThemePref"
             android:key="displayThemePref"
             android:title="@string/theme"/>
 
-        <!--suppress AndroidElementNotAllowed -->
         <com.jefftharris.passwdsafe.lib.view.LongSwitchPreference
             android:name="displayVibrateKeyboard Pref"
             android:defaultValue="false"
@@ -188,7 +166,6 @@
     <PreferenceCategory android:key="debugOptions"
         android:title="@string/debugging">
 
-        <!--suppress AndroidElementNotAllowed -->
         <com.jefftharris.passwdsafe.lib.view.LongEditTextPreference
             android:key="debugTagsPref"
             android:title="@string/logging_tags"/>

--- a/secrets-defaults.properties
+++ b/secrets-defaults.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (©) 2024 Jeff Harris <jefftharris@gmail.com>
+# Copyright (©) 2024-2025 Jeff Harris <jefftharris@gmail.com>
 # All rights reserved. Use of the code is allowed under the
 # Artistic License 2.0 terms, as specified in the LICENSE file
 # distributed with this code, or available from
@@ -11,13 +11,13 @@
 #
 # Sync app keys
 #
-BOX_CLIENT_ID = XXX
+BOX_CLIENT_ID = xxx
 
-BOX_CLIENT_SECRET = XXX
+BOX_CLIENT_SECRET = xxx
 
-DROPBOX_SYNC_APP_KEY = XXX
+DROPBOX_SYNC_APP_KEY = xxx
 
-GDRIVE_APP_ID = XXX
+GDRIVE_APP_ID = xxx
 
-ONEDRIVE_CLIENT_ID = XXX
+ONEDRIVE_CLIENT_ID = xxx
 

--- a/sync/src/main/res/xml/preferences.xml
+++ b/sync/src/main/res/xml/preferences.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (©) 2016 Jeff Harris <jefftharris@gmail.com>
+  ~ Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
   ~ All rights reserved. Use of the code is allowed under the
   ~ Artistic License 2.0 terms, as specified in the LICENSE file
   ~ distributed with this code, or available from
@@ -11,7 +11,6 @@
     <PreferenceCategory android:key="notifOptions"
                         android:title="@string/notifications">
 
-        <!--suppress AndroidElementNotAllowed -->
         <com.jefftharris.passwdsafe.lib.view.LongSwitchPreference
             android:defaultValue="true"
             android:key="notifShowSyncPref"
@@ -22,7 +21,6 @@
     <PreferenceCategory android:key="debugOptions"
         android:title="@string/debugging">
 
-        <!--suppress AndroidElementNotAllowed -->
         <com.jefftharris.passwdsafe.lib.view.LongEditTextPreference
             android:key="debugTagsPref"
             android:title="@string/logging_tags"/>


### PR DESCRIPTION
If external displays are supported, add a preference to allow the main password activity to display on an external display.  By default, the activity is marked that it shouldn't appear in the recent activities list.  An external display is not necessarily secure, so an option is added to allow display.

Addresses: GH-23