### PR TITLE
passwdsafe: Add note if saved password is removed due to invalidated key

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
 
         // From https://github.com/google/secrets-gradle-plugin
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
@@ -1004,6 +1004,7 @@ public class PasswdSafeOpenFileFragment
                             result.itsKeygenError.toString());
                     PasswdSafeUtil.showErrorMsg(msg,
                                                 new ActContext(getContext()));
+                    setPhase(Phase.WAITING_PASSWORD);
                     break;
                 }
 

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
@@ -429,6 +429,9 @@ public class PasswdSafeOpenFileFragment
         } else if (itemId == R.id.menu_nfc_settings) {
             startActivity(Settings.ACTION_NFC_SETTINGS);
             return true;
+        } else if (itemId == R.id.menu_security_settings) {
+            startActivity(Settings.ACTION_SECURITY_SETTINGS);
+            return true;
         }
         return super.onOptionsItemSelected(item);
     }

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
@@ -924,6 +924,10 @@ public class PasswdSafeOpenFileFragment
                     newState = SavedPasswordState.LOADED_SUCCESS;
                     break;
                 }
+                case KEY_INVALIDATED: {
+                    newState = SavedPasswordState.NOT_AVAILABLE;
+                    break;
+                }
                 case ERROR: {
                     newState = SavedPasswordState.LOADED_FAILURE;
                     break;
@@ -948,6 +952,7 @@ public class PasswdSafeOpenFileFragment
                     finishFileOpen(openResult.itsFileData);
                     break;
                 }
+                case KEY_INVALIDATED:
                 case ERROR: {
                     setPhase(Phase.WAITING_PASSWORD);
                     break;
@@ -970,6 +975,7 @@ public class PasswdSafeOpenFileFragment
             textColor = R.attr.textColorGreen;
             break;
         }
+        case KEY_INVALIDATED:
         case ERROR: {
             textColor = R.attr.colorError;
             break;
@@ -1342,6 +1348,8 @@ public class PasswdSafeOpenFileFragment
     {
         /** Success */
         SUCCESS,
+        /** Saved password key was invalidated */
+        KEY_INVALIDATED,
         /** Error */
         ERROR
     }
@@ -1392,6 +1400,22 @@ public class PasswdSafeOpenFileFragment
             }
             }
             finish(SavedPasswordFinish.ERROR, errString, null);
+        }
+
+        @Override
+        public final void onAuthenticationWarning(Warning warning,
+                                                  @NonNull
+                                                  CharSequence errString)
+        {
+            PasswdSafeUtil.dbginfo(itsTag, "warning %s: %s", warning,
+                                   errString);
+            switch (warning) {
+            case KEY_INVALIDATED: {
+                finish(SavedPasswordFinish.KEY_INVALIDATED,
+                       errString, null);
+                break;
+            }
+            }
         }
 
         @Override

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
@@ -45,6 +45,7 @@ import com.google.android.material.textfield.TextInputLayout;
 import com.jefftharris.passwdsafe.file.PasswdFileData;
 import com.jefftharris.passwdsafe.file.PasswdFileUri;
 import com.jefftharris.passwdsafe.lib.ActContext;
+import com.jefftharris.passwdsafe.lib.PasswdSafeLog;
 import com.jefftharris.passwdsafe.lib.PasswdSafeUtil;
 import com.jefftharris.passwdsafe.lib.view.AbstractTextWatcher;
 import com.jefftharris.passwdsafe.lib.view.GuiUtils;
@@ -426,12 +427,7 @@ public class PasswdSafeOpenFileFragment
             itsOpenModel.setYubiSlot(2);
             return true;
         } else if (itemId == R.id.menu_nfc_settings) {
-            try {
-                var intent = new Intent(Settings.ACTION_NFC_SETTINGS);
-                requireActivity().startActivity(intent);
-            } catch (Exception e) {
-                PasswdSafeUtil.dbginfo(TAG, e, "NFC activity not started");
-            }
+            startActivity(Settings.ACTION_NFC_SETTINGS);
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -1185,6 +1181,22 @@ public class PasswdSafeOpenFileFragment
                                  boolean fromYubikey)
     {
         itsOpenModel.setOpenPassword(password, fromYubikey);
+    }
+
+    /**
+     * Start an activity for an intent action
+     */
+    private void startActivity(@NonNull String action)
+    {
+        try {
+            var intent = new Intent(action);
+            var act = requireActivity();
+            if (intent.resolveActivity(act.getPackageManager()) != null) {
+                act.startActivity(intent);
+            }
+        } catch (Exception e) {
+            PasswdSafeLog.error(TAG, e, "Activity not started for %s", action);
+        }
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
@@ -1107,7 +1107,7 @@ public class PasswdSafeOpenFileFragment
                       requireView());
     }
 
-   /**
+    /**
      * Update the YubiKey progress message
      *
      * @param hasUsbDevice Non-null if the presence of a USB YubiKey is known

--- a/passwdsafe/src/main/res/layout/fragment_passwdsafe_open_file.xml
+++ b/passwdsafe/src/main/res/layout/fragment_passwdsafe_open_file.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (©) 2016-2024 Jeff Harris <jefftharris@gmail.com>
+  ~ Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
   ~ All rights reserved. Use of the code is allowed under the
   ~ Artistic License 2.0 terms, as specified in the LICENSE file
   ~ distributed with this code, or available from
@@ -55,6 +55,7 @@
                 android:gravity="fill_horizontal"
                 android:imeOptions="actionGo"
                 android:inputType="textMultiLine|textPassword"
+                android:minHeight="48dp"
                 android:scrollHorizontally="true"
                 android:textAppearance="?android:attr/textAppearanceMedium"/>
         </com.google.android.material.textfield.TextInputLayout>

--- a/passwdsafe/src/main/res/menu/fragment_passwdsafe_open_file.xml
+++ b/passwdsafe/src/main/res/menu/fragment_passwdsafe_open_file.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (©) 2016 Jeff Harris <jefftharris@gmail.com>
+  ~ Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
   ~ All rights reserved. Use of the code is allowed under the
   ~ Artistic License 2.0 terms, as specified in the LICENSE file
   ~ distributed with this code, or available from
@@ -28,6 +28,11 @@
     <item
         android:id="@+id/menu_nfc_settings"
         android:title="@string/nfc_settings"
+        app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/menu_security_settings"
+        android:title="@string/security_settings"
         app:showAsAction="never"/>
 
 </menu>

--- a/passwdsafe/src/main/res/values/strings.xml
+++ b/passwdsafe/src/main/res/values/strings.xml
@@ -356,6 +356,7 @@
         \nThe saved password may be lost during an upgrade or fingerprint
         change.  Remember the password to ensure the file remains openable.
     </string>
+    <string name="saved_password_invalid_biometrics_change" tools:ignore="MissingTranslation">The saved password has become invalid due to a biometrics change.  Choose to save the password again, and open the file with the password.</string>
     <string name="saving_file">Saving %s…</string>
     <string name="search">Search</string>
     <string name="search_hint">Search PasswdSafe</string>

--- a/passwdsafe/src/main/res/values/strings.xml
+++ b/passwdsafe/src/main/res/values/strings.xml
@@ -358,6 +358,7 @@
     </string>
     <string name="saved_password_invalid_biometrics_change" tools:ignore="MissingTranslation">The saved password has become invalid due to a biometrics change.  Choose to save the password again, and open the file with the password.</string>
     <string name="saving_file">Saving %s…</string>
+    <string name="security_settings" tools:ignore="MissingTranslation">Security Settings</string>
     <string name="search">Search</string>
     <string name="search_hint">Search PasswdSafe</string>
     <string name="select_accounts">Select accounts</string>


### PR DESCRIPTION
Detect if the key was invalidated and show a warning message indicating that the user needs to save their password again.

Add a menu to open the security settings for use if needed to fix biometrics keys, etc.

Fixes GH-21