### PR TITLE
passwdsafe: GH-27 Use pre-release of version 2.8.1 of the Yubikit-android library

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: Yubico/yubikit-android
-        ref: release/2.8.1
+        ref: d1f58c0e9b7de5e8a9e8bed5411ee5e5654d655a
         path: yubikit
 
     - name: Set up JDK 17

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,12 +15,23 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Checkout Yubikit-android
+      uses: actions/checkout@v4
+      with:
+        repository: Yubico/yubikit-android
+        ref: release/2.8.1
+        path: yubikit
+
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: gradle
+
+    - name: Build Yubikit-android
+      run: ./gradlew build publishToMavenLocal
+      working-directory: ./yubikit
 
     - name: Build with Gradle
       run: ./gradlew build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Checkout Yubikit-android
+      uses: actions/checkout@v4
+      with:
+        repository: Yubico/yubikit-android
+        ref: d1f58c0e9b7de5e8a9e8bed5411ee5e5654d655a
+        path: yubikit
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
@@ -56,6 +63,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '17'
+
+    # Build local library
+    - name: Build Yubikit-android
+      run: ./gradlew build publishToMavenLocal
+      working-directory: ./yubikit
 
     # Build native code for C++
     - name: C++ Build

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'com.android.tools.build:gradle:8.10.0'
 
         // From https://github.com/google/secrets-gradle-plugin
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
         maven {
             url = uri("${rootProject.projectDir}/maven-libs")
         }

--- a/passwdsafe/build.gradle
+++ b/passwdsafe/build.gradle
@@ -82,7 +82,7 @@ android {
 
 dependencies {
     def room_version = "2.6.1"
-    def yubikey_version = "2.7.0"
+    def yubikey_version = "2.8.1-SNAPSHOT"
     def espresso_version = "3.6.1"
 
     implementation fileTree(include: ['*.jar'], dir: 'libs')


### PR DESCRIPTION
For the fix to GH-27, a local, pre-release of version 2.8.1 of the Yubikit-android library is used.

Update the Github workflow to build the publish the Yubikit-android library to a local maven repository.