### PR TITLE
passwdsafe: Add support for last file password change

### DIFF
--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/AboutFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/AboutFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -19,6 +19,8 @@ import androidx.fragment.app.Fragment;
 
 import com.jefftharris.passwdsafe.lib.AboutUtils;
 import com.jefftharris.passwdsafe.lib.view.GuiUtils;
+
+import org.jetbrains.annotations.Contract;
 
 import java.util.Locale;
 
@@ -49,10 +51,13 @@ public class AboutFragment extends Fragment
     private TextView itsLastSaveBy;
     private TextView itsLastSaveApp;
     private TextView itsLastSaveTime;
+    private TextView itsLastPasswordChange;
 
     /**
      * Create a new instance
      */
+    @NonNull
+    @Contract(" -> new")
     public static AboutFragment newInstance()
     {
         return new AboutFragment();
@@ -90,6 +95,8 @@ public class AboutFragment extends Fragment
         itsLastSaveBy = rootView.findViewById(R.id.last_save_by);
         itsLastSaveApp = rootView.findViewById(R.id.last_save_app);
         itsLastSaveTime = rootView.findViewById(R.id.last_save_time);
+        itsLastPasswordChange =
+                rootView.findViewById(R.id.last_password_change);
         return rootView;
     }
 
@@ -130,11 +137,14 @@ public class AboutFragment extends Fragment
                                 fileData.getHdrLastSaveApp());
                         itsLastSaveTime.setText(
                                 fileData.getHdrLastSaveTime());
+                        itsLastPasswordChange.setText(
+                                fileData.getHdrLastPasswordChange());
                     } else {
                         itsDatabaseVer.setText(null);
                         itsLastSaveBy.setText(null);
                         itsLastSaveApp.setText(null);
                         itsLastSaveTime.setText(null);
+                        itsLastPasswordChange.setText(null);
                     }
                     return true;
                 });

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
@@ -221,6 +221,7 @@ public class PasswdFileData
 
     public final void changePasswd(Owner<PwsPassword>.Param passwd)
     {
+        setHdrLastPasswordChange(new Date());
         itsPwsFile.setPassphrase(passwd);
     }
 
@@ -670,6 +671,12 @@ public class PasswdFileData
         return getHdrField(PwsHeaderTypeV3.LAST_PASSWORD_CHANGE);
     }
 
+    private void setHdrLastPasswordChange(Date date)
+    {
+        setHdrField(PwsHeaderTypeV3.LAST_PASSWORD_CHANGE, date);
+        updateFormatVersion(PwsRecordV3.DB_FMT_MINOR_3_47);
+    }
+
 
     /** Get the named password policies from the file header */
     public HeaderPasswdPolicies getHdrPasswdPolicies()
@@ -1013,7 +1020,8 @@ public class PasswdFileData
         if (isV3()) {
             PwsRecord rec = ((PwsFileV3)itsPwsFile).getHeaderRecord();
             switch (fieldId) {
-            case LAST_SAVE_TIME: {
+            case LAST_SAVE_TIME:
+            case LAST_PASSWORD_CHANGE: {
                 long timeVal = ((Date)value).getTime();
                 byte[] newbytes;
                 int minor = getHdrMinorVersion(rec);

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
@@ -665,6 +665,11 @@ public class PasswdFileData
         setHdrField(PwsHeaderTypeV3.LAST_SAVE_TIME, date);
     }
 
+    public final String getHdrLastPasswordChange()
+    {
+        return getHdrField(PwsHeaderTypeV3.LAST_PASSWORD_CHANGE);
+    }
+
 
     /** Get the named password policies from the file header */
     public HeaderPasswdPolicies getHdrPasswdPolicies()
@@ -947,7 +952,8 @@ public class PasswdFileData
                 return String.format(Locale.US, "%d.%02d", 3,
                                      getHdrMinorVersion(rec));
             }
-            case LAST_SAVE_TIME: {
+            case LAST_SAVE_TIME:
+            case LAST_PASSWORD_CHANGE: {
                 PwsField time = doGetHeaderField(rec, fieldId);
                 if (time == null) {
                     return null;

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsHeaderTypeV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsHeaderTypeV3.java
@@ -21,6 +21,7 @@ public enum PwsHeaderTypeV3 implements PwsFieldType
     LAST_SAVE_HOST(0x08),
     NAMED_PASSWORD_POLICIES(0x10),
     YUBICO(0x12),
+    LAST_PASSWORD_CHANGE(0x13),
     END_OF_RECORD(255);
 
     private final int itsId;

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
@@ -54,6 +54,11 @@ public class PwsRecordV3 extends PwsRecord
     public static final byte DB_FMT_MINOR_3_30 = 0x0D;
 
     /**
+     * Minor version for PasswordSafe 3.47
+     */
+    public static final byte DB_FMT_MINOR_3_47 = 0x0E;
+
+    /**
      * Minor version of the max supported database format
      */
     public static final byte DB_FMT_MINOR_VERSION = DB_FMT_MINOR_3_30;

--- a/passwdsafe/src/main/res/layout/fragment_about.xml
+++ b/passwdsafe/src/main/res/layout/fragment_about.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (©) 2015-2024 Jeff Harris <jefftharris@gmail.com>
+  ~ Copyright (©) 2015-2025 Jeff Harris <jefftharris@gmail.com>
   ~ All rights reserved. Use of the code is allowed under the
   ~ Artistic License 2.0 terms, as specified in the LICENSE file
   ~ distributed with this code, or available from
@@ -96,6 +96,14 @@
 
             <TextView
                 android:id="@+id/last_save_time"
+                style="@style/GridField.W3"/>
+
+            <TextView
+                style="@style/GridLabel"
+                android:text="@string/last_password_change"/>
+
+            <TextView
+                android:id="@+id/last_password_change"
                 style="@style/GridField.W3"/>
 
         </androidx.gridlayout.widget.GridLayout>

--- a/passwdsafe/src/main/res/values-de/strings.xml
+++ b/passwdsafe/src/main/res/values-de/strings.xml
@@ -190,6 +190,7 @@
         SD-Karten schreiben. Wenn sich die Datei dort befindet,
         wird sie in den internen Speicher kopiert.
     </string>
+    <string name="last_password_change">Last password change</string>
     <string name="last_save_app">Letzte App</string>
     <string name="last_save_by">Gespeichert von</string>
     <string name="last_save_time">Gespeichert am</string>

--- a/passwdsafe/src/main/res/values-fr/strings.xml
+++ b/passwdsafe/src/main/res/values-fr/strings.xml
@@ -197,6 +197,7 @@
         d\'écrire sur des cartes SD amovibles. Si le fichier est situé sur
         une carte, il devra être déplacé vers la mémoire interne.
     </string>
+    <string name="last_password_change">Last password change</string>
     <string name="last_save_app">Application utilisée</string>
     <string name="last_save_by">Dernier enregistrement par</string>
     <string name="last_save_time">Dernier enregistrement le</string>

--- a/passwdsafe/src/main/res/values-nb/strings.xml
+++ b/passwdsafe/src/main/res/values-nb/strings.xml
@@ -180,6 +180,7 @@
     <string name="key_error">Nøkkelfeil for %1$s: %2$s</string>
     <string name="key_not_found">Nøkkel ikke funnet for %1$s</string>
     <string name="kitkat_sdcard_warning">%1$s \n\nPå Android KitKat og nyere er apper forhindret fra å skrive til fjernbare SD-kort. Hvis filen er lokalisert på et slikt kort, den må flyttes til intern lagring.</string>
+    <string name="last_password_change">Last password change</string>
     <string name="last_save_app">Siste lagrede app</string>
     <string name="last_save_by">Sist lagret av</string>
     <string name="last_save_time">Siste lagringstidspunkt</string>

--- a/passwdsafe/src/main/res/values/strings.xml
+++ b/passwdsafe/src/main/res/values/strings.xml
@@ -188,6 +188,7 @@
         removable SD cards.  If the file is located on a card, it will have to
         be moved to the internal storage.
     </string>
+    <string name="last_password_change">Last password change</string>
     <string name="last_save_app">Last saved app</string>
     <string name="last_save_by">Last saved by</string>
     <string name="last_save_time">Last save time</string>


### PR DESCRIPTION
The file format is bumped to 0x0E when the header is added to match when the field was added to the file format.

Awaiting translations.

Addresses: https://github.com/jefftharris/passwdsafe/issues/42