### PR TITLE
gradle: Use key=value assignments

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,8 +16,8 @@ static def buildTime() {
 }
 
 android {
-    namespace 'com.jefftharris.passwdsafe.lib'
-    compileSdk 35
+    namespace = 'com.jefftharris.passwdsafe.lib'
+    compileSdk = 35
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 35
@@ -26,11 +26,11 @@ android {
         buildConfigField 'String', 'BUILD_DATE', "\"${buildTime()}\""
     }
     buildFeatures {
-        buildConfig true
+        buildConfig = true
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     productFlavors {
     }

--- a/passwdsafe/build.gradle
+++ b/passwdsafe/build.gradle
@@ -9,17 +9,17 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace 'com.jefftharris.passwdsafe'
-    compileSdk 35
+    namespace = 'com.jefftharris.passwdsafe'
+    compileSdk = 35
     defaultConfig {
-        applicationId "com.jefftharris.passwdsafe"
+        applicationId = "com.jefftharris.passwdsafe"
         minSdkVersion 21
         resourceConfigurations += ['de', 'fr', 'nb']
         targetSdkVersion 35
         // <major><minor><bugfix><beta/extra>
-        versionCode 6250100
-        versionName "6.25.1"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        versionCode = 6250100
+        versionName = "6.25.1"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
 
         javaCompileOptions {
@@ -31,11 +31,11 @@ android {
         }
     }
     buildFeatures {
-        buildConfig true
+        buildConfig = true
     }
     buildTypes {
         debug {
-            debuggable true
+            debuggable = true
             proguardFiles += getDefaultProguardFile(
                     'proguard-android-optimize.txt')
             proguardFiles += 'proguard-rules.pro'
@@ -44,38 +44,38 @@ android {
                     'proguard-android-optimize.txt')
             testProguardFiles += 'proguard-rules-test.pro'
             ndk {
-                debugSymbolLevel "FULL"
+                debugSymbolLevel = "FULL"
             }
         }
         release {
-            minifyEnabled true
+            minifyEnabled = true
             proguardFiles += getDefaultProguardFile(
                     'proguard-android-optimize.txt')
             proguardFiles += 'proguard-rules.pro'
             ndk {
-                debugSymbolLevel "FULL"
+                debugSymbolLevel = "FULL"
             }
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     productFlavors {
     }
     externalNativeBuild {
         cmake {
-            path 'src/main/cpp/CMakeLists.txt'
+            path = 'src/main/cpp/CMakeLists.txt'
         }
     }
     ndkVersion = '28.0.13004108'
     packagingOptions {
         jniLibs {
-            useLegacyPackaging false
+            useLegacyPackaging = false
         }
     }
     testOptions {
-        animationsDisabled true
+        animationsDisabled = true
     }
 }
 

--- a/sync/build.gradle
+++ b/sync/build.gradle
@@ -9,24 +9,24 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 
 android {
-    namespace 'com.jefftharris.passwdsafe.sync'
-    compileSdk 35
+    namespace = 'com.jefftharris.passwdsafe.sync'
+    compileSdk = 35
     defaultConfig {
-        applicationId "com.jefftharris.passwdsafe.sync"
+        applicationId = "com.jefftharris.passwdsafe.sync"
         minSdkVersion 26
         resourceConfigurations += ['de', 'fr', 'nb']
         targetSdkVersion 35
         // <major><minor><bugfix><beta/extra>
-        versionCode 3120001
-        versionName "3.12.0"
+        versionCode = 3120001
+        versionName = "3.12.0"
         vectorDrawables.useSupportLibrary = true
     }
     buildFeatures {
-        buildConfig true
+        buildConfig = true
     }
     buildTypes {
         debug {
-            debuggable true
+            debuggable = true
             // Uncomment below option to minify during debug development
             // minifyEnabled true
             proguardFiles += getDefaultProguardFile(
@@ -35,7 +35,7 @@ android {
             proguardFiles += 'proguard-google-api-client.pro'
         }
         release {
-            minifyEnabled true
+            minifyEnabled = true
             proguardFiles += getDefaultProguardFile(
                     'proguard-android-optimize.txt')
             proguardFiles += 'proguard-rules.pro'
@@ -50,8 +50,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     productFlavors {
     }


### PR DESCRIPTION
Update property assignments to use key=value style.  Other assignments styles are deprecated.