### PR TITLE
passwdsafe: Clarify confirm dialog when cancelling a record edit

### DIFF
--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
@@ -1747,10 +1747,10 @@ public class PasswdSafe extends AppCompatActivity
                 navRun.run();
             };
             new AlertDialog.Builder(this)
-                    .setTitle(R.string.continue_p)
+                    .setTitle(R.string.discard_unsaged_changes_p)
                     .setMessage(R.string.any_changes_will_be_lost)
-                    .setPositiveButton(R.string.continue_str, listener)
-                    .setNegativeButton(R.string.cancel, null)
+                    .setPositiveButton(R.string.discard, listener)
+                    .setNegativeButton(R.string.keep_editing, null)
                     .show();
         } else {
             navRun.run();

--- a/passwdsafe/src/main/res/values-de/strings.xml
+++ b/passwdsafe/src/main/res/values-de/strings.xml
@@ -49,8 +49,6 @@
     <string name="confirm">Bestätigen</string>
     <string name="cannot_delete_record">Eintrag kann nicht gelöscht werden - %1$s</string>
     <string name="content_file">Inhaltsdatei</string>
-    <string name="continue_str">Weiter</string>
-    <string name="continue_p">Fortsetzen?</string>
     <string name="copy_email">E-Mail kopieren</string>
     <string name="copy_notes">Notizen kopieren</string>
     <string name="copy_password">Passwort kopieren</string>

--- a/passwdsafe/src/main/res/values-fr/strings.xml
+++ b/passwdsafe/src/main/res/values-fr/strings.xml
@@ -50,8 +50,6 @@
     <string name="confirm">Confirmer</string>
     <string name="cannot_delete_record">Impossible de supprimer l\'entrée - %1$s"</string>
     <string name="content_file">Contenu du fichier</string>
-    <string name="continue_str">Continuer</string>
-    <string name="continue_p">Continuer?</string>
     <string name="copy_email">Copier Email</string>
     <string name="copy_notes">Copier les notes</string>
     <string name="copy_password">Copier le mot de passe</string>

--- a/passwdsafe/src/main/res/values-nb/strings.xml
+++ b/passwdsafe/src/main/res/values-nb/strings.xml
@@ -48,8 +48,6 @@
     <string name="confirm">Bekreft</string>
     <string name="cannot_delete_record">Klarte ikke slette oppføring - %1$s</string>
     <string name="content_file">Innholdsfil</string>
-    <string name="continue_str">Fortsett</string>
-    <string name="continue_p">Fortsett?</string>
     <string name="copy_email">Kopier e-post</string>
     <string name="copy_notes">Kopier notater</string>
     <string name="copy_password">Kopier passord</string>

--- a/passwdsafe/src/main/res/values/strings.xml
+++ b/passwdsafe/src/main/res/values/strings.xml
@@ -47,8 +47,6 @@
     <string name="confirm">Confirm</string>
     <string name="cannot_delete_record">Cannot delete record - %1$s</string>
     <string name="content_file">Content File</string>
-    <string name="continue_str">Continue</string>
-    <string name="continue_p">Continue?</string>
     <string name="copy_email">Copy Email</string>
     <string name="copy_notes">Copy Notes</string>
     <string name="copy_password">Copy Password</string>
@@ -81,6 +79,8 @@
     <string name="delete_policy_msg">Delete policy \"%1$s\"?</string>
     <string name="delete_record_msg">Delete record \"%1$s\"?</string>
     <string name="directory_for_files">Directory for files</string>
+    <string name="discard" tools:ignore="MissingTranslation">Discard</string>
+    <string name="discard_unsaged_changes_p" tools:ignore="MissingTranslation">Discard unsaved changes?</string>
     <string name="display">Display</string>
     <string name="done">Done</string>
     <string name="duplicate_entry">Duplicate entry</string>
@@ -180,6 +180,7 @@
     <string name="invalid_length">Invalid length</string>
     <string name="invalid_option_length">Invalid option length</string>
     <string name="invalid_password">Invalid password</string>
+    <string name="keep_editing" tools:ignore="MissingTranslation">Keep editing</string>
     <string name="key_error">Key error for %1$s: %2$s</string>
     <string name="key_not_found">Key not found for %1$s</string>
     <string name="kitkat_sdcard_warning">


### PR DESCRIPTION
Clarify the title and buttons that 'Cancel' remains editing, and 'Continue' discards any changes.

Addresses: GH-49