### PR TITLE
passwdsafe: file: GH-55 Fix loads of unknown record fields

### DIFF
--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecord.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecord.java
@@ -451,7 +451,7 @@ public abstract class PwsRecord implements Comparable<Object>, Serializable
         }
 
         // try a shortcut first
-        if (theType < ValidTypes.length) {
+        if ((theType >= 0) && (theType < ValidTypes.length)) {
             if ((Integer)((Object[])ValidTypes[theType])[0] == theType) {
                 Class<? extends PwsField> cl = value.getClass();
 

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV2.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV2.java
@@ -196,10 +196,12 @@ public class PwsRecordV2 extends PwsRecord
                                                   item.getByteData());
                     break;
 
-                case PASSWORD_POLICY:
+                case PASSWORD_POLICY: {
+                    nullIsError = false;
+                    break;
+                }
                 case END_OF_RECORD:
                 case UNKNOWN:
-                    nullIsError = false;
                     break;
                 }
                 if (itemVal != null) {

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
@@ -402,7 +402,8 @@ public class PwsRecordV3 extends PwsRecord
                         break;
                     }
                     if (itemVal == null) {
-                        itemVal = new PwsUnknownField(type, item.getByteData());
+                        itemVal = new PwsUnknownField(itemType,
+                                                      item.getByteData());
                     }
                     setField(itemVal);
                 }


### PR DESCRIPTION
Fix errors looking up the valid type for unknown fields.  Fix use of original field type for unknown fields.  Fix load of V2 password policy fields.

Addresses: GH-55