### PR TITLE
passwdsafe: file: Use typed fields for the header record

### DIFF
--- a/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/FileV3Test.java
+++ b/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/FileV3Test.java
@@ -39,17 +39,37 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+// TODO: Add header tests using 8byte times for last save and password change,
+// or perhaps just generic PwsTimeField tests
+
 /**
  * Low-level tests for V3 files
  */
 public class FileV3Test
 {
-    // TODO: Verify file header fields
-
-    private interface LoadSaveTester
+    private abstract static class LoadSaveTester
     {
-        void populate(PwsFile file);
-        void verify(PwsFile file);
+        protected V3FileInfo itsFileInfo;
+
+        public final void parseNewFileInfo(PwsFile file)
+        {
+            itsFileInfo = new V3FileInfo(file);
+            itsFileInfo.populateHeader();
+        }
+
+        public abstract void populate(PwsFile file);
+
+        public final void verify(@NonNull PwsFile file)
+        {
+            assertTrue(file instanceof PwsFileV3);
+            assertFalse(file.isReadOnly());
+
+            itsFileInfo.verifyFileHeader(file);
+
+            doVerify(file);
+        }
+
+        protected abstract void doVerify(PwsFile file);
     }
 
     private static class RecInfo
@@ -79,7 +99,7 @@ public class FileV3Test
         public static UUID getUuid(@NonNull PwsRecord rec)
         {
             var uuid = rec.getField(PwsFieldTypeV3.UUID);
-            assertNotNull(uuid);
+            assertTrue(uuid instanceof PwsUUIDField);
             return (UUID)uuid.getValue();
         }
     }
@@ -95,7 +115,7 @@ public class FileV3Test
             }
 
             @Override
-            public void verify(PwsFile file)
+            public void doVerify(PwsFile file)
             {
                 verifyEmpty(file);
             }
@@ -117,11 +137,8 @@ public class FileV3Test
             }
 
             @Override
-            public void verify(PwsFile file)
+            public void doVerify(PwsFile file)
             {
-                assertTrue(file instanceof PwsFileV3);
-                assertFalse(file.isReadOnly());
-
                 assertEquals(1, file.getRecordCount());
                 int idx = 0;
                 var recIter = file.getRecords();
@@ -154,11 +171,8 @@ public class FileV3Test
             }
 
             @Override
-            public void verify(PwsFile file)
+            public void doVerify(PwsFile file)
             {
-                assertTrue(file instanceof PwsFileV3);
-                assertFalse(file.isReadOnly());
-
                 assertEquals(100, file.getRecordCount());
                 int idx = 0;
                 TreeSet<UUID> verifyUuids = new TreeSet<>();
@@ -207,15 +221,16 @@ public class FileV3Test
                                             PwsFieldTypeV3.UNKNOWN,
                                             itsRec1.itsUnknownValue2));
 
+                itsFileInfo.populateUnknownHeader(0xe0,
+                                                  itsRec1.itsUnknownValue1,
+                                                  0xe1,
+                                                  itsRec1.itsUnknownValue2);
                 file.add(itsRec1.itsRec);
             }
 
             @Override
-            public void verify(PwsFile file)
+            public void doVerify(PwsFile file)
             {
-                assertTrue(file instanceof PwsFileV3);
-                assertFalse(file.isReadOnly());
-
                 assertEquals(1, file.getRecordCount());
                 int idx = 0;
                 var recIter = file.getRecords();
@@ -238,6 +253,7 @@ public class FileV3Test
                 var file = createFile(saveFile);
                 try {
                     file.setPassphrase(PASSWD.pass());
+                    tester.parseNewFileInfo(file);
                     verifyEmpty(file);
                     tester.populate(file);
                     tester.verify(file);

--- a/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/FileV3Test.java
+++ b/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/FileV3Test.java
@@ -39,9 +39,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-// TODO: Add header tests using 8byte times for last save and password change,
-// or perhaps just generic PwsTimeField tests
-
 /**
  * Low-level tests for V3 files
  */
@@ -53,10 +50,14 @@ public class FileV3Test
 
         public final void parseNewFileInfo(PwsFile file)
         {
-            itsFileInfo = new V3FileInfo(file);
+            itsFileInfo = new V3FileInfo(file, getHdrTimeFormat());
             itsFileInfo.populateHeader();
         }
 
+        public PwsTimeField.Format getHdrTimeFormat()
+        {
+            return PwsTimeField.Format.DEFAULT;
+        }
         public abstract void populate(PwsFile file);
 
         public final void verify(@NonNull PwsFile file)
@@ -239,6 +240,30 @@ public class FileV3Test
                     var rec = recIter.next();
                     verifyFields(rec, itsRec1);
                 }
+            }
+        });
+    }
+
+    @Test
+    public void testHdrAsciiTime() throws Exception
+    {
+        doTestLoadSave(new LoadSaveTester()
+        {
+            @Override
+            public PwsTimeField.Format getHdrTimeFormat()
+            {
+                return PwsTimeField.Format.HEADER_ASCII;
+            }
+
+            @Override
+            public void populate(PwsFile file)
+            {
+            }
+
+            @Override
+            public void doVerify(PwsFile file)
+            {
+                verifyEmpty(file);
             }
         });
     }

--- a/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/V3FileInfo.java
+++ b/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/V3FileInfo.java
@@ -39,6 +39,8 @@ class V3FileInfo
     private final PwsRecord itsHeaderRec;
     private final int itsVersion;
     private final UUID itsUuid;
+    private String itsNonDefaultPrefs;
+    private String itsTreeDisplayStatus;
     private Date itsLastSaveTime;
     private final String itsLastSaveWho;
     private String itsLastSaveWhat;
@@ -68,6 +70,9 @@ class V3FileInfo
 
         itsUuid = getUuid(itsHeaderRec);
 
+        itsNonDefaultPrefs = getHeaderStr(PwsHeaderTypeV3.NON_DEFAULT_PREFS);
+        itsTreeDisplayStatus =
+                getHeaderStr(PwsHeaderTypeV3.TREE_DISPLAY_STATUS);
         itsLastSaveTime = getHeaderTime(PwsHeaderTypeV3.LAST_SAVE_TIME);
         itsLastSaveWho = getHeaderStr(PwsHeaderTypeV3.LAST_SAVE_WHO);
         itsLastSaveWhat = getHeaderStr(PwsHeaderTypeV3.LAST_SAVE_WHAT);
@@ -82,6 +87,18 @@ class V3FileInfo
 
     public void populateHeader()
     {
+        assertNull(itsNonDefaultPrefs);
+        itsNonDefaultPrefs = String.format("I 11 2 S 12 %s", itsUuid);
+        itsHeaderRec.setField(
+                new PwsStringUnicodeField(PwsHeaderTypeV3.NON_DEFAULT_PREFS,
+                                          itsNonDefaultPrefs));
+
+        assertNull(itsTreeDisplayStatus);
+        itsTreeDisplayStatus = "10100001101";
+        itsHeaderRec.setField(
+                new PwsStringUnicodeField(PwsHeaderTypeV3.TREE_DISPLAY_STATUS,
+                                          itsTreeDisplayStatus));
+
         assertNull(itsLastSaveTime);
         itsLastSaveTime = PwsTimeField.normalizeDate(new Date());
         itsHeaderRec.setField(new PwsTimeField(PwsHeaderTypeV3.LAST_SAVE_TIME,
@@ -148,6 +165,10 @@ class V3FileInfo
         assertNotNull(itsUuid);
         assertEquals(itsUuid, fileInfo.itsUuid);
         assertEquals(itsVersion, fileInfo.itsVersion);
+        assertNotNull(itsNonDefaultPrefs);
+        assertEquals(itsNonDefaultPrefs, fileInfo.itsNonDefaultPrefs);
+        assertNotNull(itsTreeDisplayStatus);
+        assertEquals(itsTreeDisplayStatus, fileInfo.itsTreeDisplayStatus);
         assertNotNull(itsLastSaveTime);
         assertEquals(itsLastSaveTime, fileInfo.itsLastSaveTime);
         assertNull(itsLastSaveWho);
@@ -175,9 +196,16 @@ class V3FileInfo
             switch (PwsHeaderTypeV3.fromType(headerFieldId)) {
             case VERSION,
                  UUID,
-                 LAST_SAVE_TIME, LAST_SAVE_WHO, LAST_SAVE_WHAT,
-                 LAST_SAVE_USER, LAST_SAVE_HOST, NAMED_PASSWORD_POLICIES,
-                 YUBICO, LAST_PASSWORD_CHANGE -> {
+                 NON_DEFAULT_PREFS,
+                 TREE_DISPLAY_STATUS,
+                 LAST_SAVE_TIME,
+                 LAST_SAVE_WHO,
+                 LAST_SAVE_WHAT,
+                 LAST_SAVE_USER,
+                 LAST_SAVE_HOST,
+                 NAMED_PASSWORD_POLICIES,
+                 YUBICO,
+                 LAST_PASSWORD_CHANGE -> {
             }
             case END_OF_RECORD -> fail();
             case UNKNOWN -> {

--- a/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/V3FileInfo.java
+++ b/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/V3FileInfo.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.fail;
 class V3FileInfo
 {
     private final PwsRecord itsHeaderRec;
+    private final PwsTimeField.Format itsHdrTimeFormat;
     private final int itsVersion;
     private final UUID itsUuid;
     private String itsNonDefaultPrefs;
@@ -54,9 +55,10 @@ class V3FileInfo
     private int itsUnknownField2 = -1;
     private byte[] itsUnknownValue2 = null;
 
-    public V3FileInfo(PwsFile file)
+    public V3FileInfo(PwsFile file, PwsTimeField.Format hdrTimeFormat)
     {
         itsHeaderRec = getHeaderRec(file);
+        itsHdrTimeFormat = hdrTimeFormat;
 
         var version = itsHeaderRec.getField(PwsHeaderTypeV3.VERSION);
         assertTrue(version instanceof PwsVersionField);
@@ -102,7 +104,7 @@ class V3FileInfo
         assertNull(itsLastSaveTime);
         itsLastSaveTime = PwsTimeField.normalizeDate(new Date());
         itsHeaderRec.setField(new PwsTimeField(PwsHeaderTypeV3.LAST_SAVE_TIME,
-                                               PwsTimeField.Format.DEFAULT,
+                                               itsHdrTimeFormat,
                                                itsLastSaveTime));
 
         assertNull(itsLastSaveWhat);
@@ -139,8 +141,7 @@ class V3FileInfo
         itsLastPasswordChange = PwsTimeField.normalizeDate(new Date());
         itsHeaderRec.setField(
                 new PwsTimeField(PwsHeaderTypeV3.LAST_PASSWORD_CHANGE,
-                                 PwsTimeField.Format.DEFAULT,
-                                 itsLastPasswordChange));
+                                 itsHdrTimeFormat, itsLastPasswordChange));
     }
 
     public void populateUnknownHeader(int field1, byte[] value1,
@@ -161,7 +162,7 @@ class V3FileInfo
 
     public void verifyFileHeader(@NonNull PwsFile file)
     {
-        V3FileInfo fileInfo = new V3FileInfo(file);
+        V3FileInfo fileInfo = new V3FileInfo(file, itsHdrTimeFormat);
         assertNotNull(itsUuid);
         assertEquals(itsUuid, fileInfo.itsUuid);
         assertEquals(itsVersion, fileInfo.itsVersion);
@@ -190,22 +191,37 @@ class V3FileInfo
 
         boolean unknown1Verified = false;
         boolean unknown2Verified = false;
+        boolean lastSaveTimeVerified = false;
+        boolean lastPasswordChangeVerified = false;
         for(var headerFieldIter = fileInfo.itsHeaderRec.getFields();
             headerFieldIter.hasNext(); ) {
             var headerFieldId = headerFieldIter.next();
-            switch (PwsHeaderTypeV3.fromType(headerFieldId)) {
+            var headerType = PwsHeaderTypeV3.fromType(headerFieldId);
+            switch (headerType) {
             case VERSION,
                  UUID,
                  NON_DEFAULT_PREFS,
                  TREE_DISPLAY_STATUS,
-                 LAST_SAVE_TIME,
                  LAST_SAVE_WHO,
                  LAST_SAVE_WHAT,
                  LAST_SAVE_USER,
                  LAST_SAVE_HOST,
                  NAMED_PASSWORD_POLICIES,
-                 YUBICO,
-                 LAST_PASSWORD_CHANGE -> {
+                 YUBICO -> {
+            }
+            case LAST_SAVE_TIME, LAST_PASSWORD_CHANGE -> {
+                var headerField = fileInfo.itsHeaderRec.getField(headerFieldId);
+                var bytes = headerField.getBytes();
+                switch (itsHdrTimeFormat) {
+                case DEFAULT -> assertEquals(4, bytes.length);
+                case HEADER_ASCII -> assertEquals(8, bytes.length);
+                }
+
+                switch (headerType) {
+                case LAST_SAVE_TIME -> lastSaveTimeVerified = true;
+                case LAST_PASSWORD_CHANGE -> lastPasswordChangeVerified =
+                        true;
+                }
             }
             case END_OF_RECORD -> fail();
             case UNKNOWN -> {
@@ -237,6 +253,8 @@ class V3FileInfo
 
         assertEquals(itsUnknownField1 != -1, unknown1Verified);
         assertEquals(itsUnknownField2 != -1, unknown2Verified);
+        assertTrue(lastSaveTimeVerified);
+        assertTrue(lastPasswordChangeVerified);
     }
 
     private static PwsRecord getHeaderRec(@NonNull PwsFile file)

--- a/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/V3FileInfo.java
+++ b/passwdsafe/src/androidTest/java/com/jefftharris/passwdsafe/test/file/V3FileInfo.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (©) 2025 Jeff Harris <jefftharris@gmail.com>
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+package com.jefftharris.passwdsafe.test.file;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.pwsafe.lib.UUID;
+import org.pwsafe.lib.file.PwsFile;
+import org.pwsafe.lib.file.PwsFileV3;
+import org.pwsafe.lib.file.PwsHeaderTypeV3;
+import org.pwsafe.lib.file.PwsRecord;
+import org.pwsafe.lib.file.PwsRecordV3;
+import org.pwsafe.lib.file.PwsStringUnicodeField;
+import org.pwsafe.lib.file.PwsTimeField;
+import org.pwsafe.lib.file.PwsUUIDField;
+import org.pwsafe.lib.file.PwsUnknownField;
+import org.pwsafe.lib.file.PwsVersionField;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Testing V3 file info
+ */
+class V3FileInfo
+{
+    private final PwsRecord itsHeaderRec;
+    private final int itsVersion;
+    private final UUID itsUuid;
+    private Date itsLastSaveTime;
+    private final String itsLastSaveWho;
+    private String itsLastSaveWhat;
+    private String itsLastSaveUser;
+    private String itsLastSaveHost;
+    private String itsNamedPasswordPolicies;
+    private String itsYubico;
+    private Date itsLastPasswordChange;
+    private int itsUnknownField1 = -1;
+    private byte[] itsUnknownValue1 = null;
+    private int itsUnknownField2 = -1;
+    private byte[] itsUnknownValue2 = null;
+
+    public V3FileInfo(PwsFile file)
+    {
+        itsHeaderRec = getHeaderRec(file);
+
+        var version = itsHeaderRec.getField(PwsHeaderTypeV3.VERSION);
+        assertTrue(version instanceof PwsVersionField);
+        assertTrue(version.getValue() instanceof Integer);
+        itsVersion = (Integer)version.getValue();
+        assertEquals((3 << 24 | PwsRecordV3.DB_FMT_MINOR_3_30 << 16),
+                     itsVersion);
+        assertEquals(3, ((PwsVersionField)version).getMajor());
+        assertEquals(PwsRecordV3.DB_FMT_MINOR_3_30,
+                     ((PwsVersionField)version).getMinor());
+
+        itsUuid = getUuid(itsHeaderRec);
+
+        itsLastSaveTime = getHeaderTime(PwsHeaderTypeV3.LAST_SAVE_TIME);
+        itsLastSaveWho = getHeaderStr(PwsHeaderTypeV3.LAST_SAVE_WHO);
+        itsLastSaveWhat = getHeaderStr(PwsHeaderTypeV3.LAST_SAVE_WHAT);
+        itsLastSaveUser = getHeaderStr(PwsHeaderTypeV3.LAST_SAVE_USER);
+        itsLastSaveHost = getHeaderStr(PwsHeaderTypeV3.LAST_SAVE_HOST);
+        itsNamedPasswordPolicies =
+                getHeaderStr(PwsHeaderTypeV3.NAMED_PASSWORD_POLICIES);
+        itsYubico = getHeaderStr(PwsHeaderTypeV3.YUBICO);
+        itsLastPasswordChange =
+                getHeaderTime(PwsHeaderTypeV3.LAST_PASSWORD_CHANGE);
+    }
+
+    public void populateHeader()
+    {
+        assertNull(itsLastSaveTime);
+        itsLastSaveTime = PwsTimeField.normalizeDate(new Date());
+        itsHeaderRec.setField(new PwsTimeField(PwsHeaderTypeV3.LAST_SAVE_TIME,
+                                               PwsTimeField.Format.DEFAULT,
+                                               itsLastSaveTime));
+
+        assertNull(itsLastSaveWhat);
+        itsLastSaveWhat = String.format("APP - %s", itsUuid);
+        itsHeaderRec.setField(
+                new PwsStringUnicodeField(PwsHeaderTypeV3.LAST_SAVE_WHAT,
+                                          itsLastSaveWhat));
+
+        assertNull(itsLastSaveUser);
+        itsLastSaveUser = String.format("USER - %s", itsUuid);
+        itsHeaderRec.setField(
+                new PwsStringUnicodeField(PwsHeaderTypeV3.LAST_SAVE_USER,
+                                          itsLastSaveUser));
+
+        assertNull(itsLastSaveHost);
+        itsLastSaveHost = String.format("HOST - %s", itsUuid);
+        itsHeaderRec.setField(
+                new PwsStringUnicodeField(PwsHeaderTypeV3.LAST_SAVE_HOST,
+                                          itsLastSaveHost));
+
+        assertNull(itsNamedPasswordPolicies);
+        itsNamedPasswordPolicies =
+                String.format("HEADER POLICIES - %s", itsUuid);
+        itsHeaderRec.setField(new PwsStringUnicodeField(
+                PwsHeaderTypeV3.NAMED_PASSWORD_POLICIES,
+                itsNamedPasswordPolicies));
+
+        assertNull(itsYubico);
+        itsYubico = String.format("YUBICO - %s", itsUuid);
+        itsHeaderRec.setField(
+                new PwsStringUnicodeField(PwsHeaderTypeV3.YUBICO, itsYubico));
+
+        assertNull(itsLastPasswordChange);
+        itsLastPasswordChange = PwsTimeField.normalizeDate(new Date());
+        itsHeaderRec.setField(
+                new PwsTimeField(PwsHeaderTypeV3.LAST_PASSWORD_CHANGE,
+                                 PwsTimeField.Format.DEFAULT,
+                                 itsLastPasswordChange));
+    }
+
+    public void populateUnknownHeader(int field1, byte[] value1,
+                                      int field2, byte[] value2)
+    {
+        itsUnknownField1 = field1;
+        itsUnknownValue1 = value1;
+        itsHeaderRec.setField(
+                new PwsUnknownField(itsUnknownField1, PwsHeaderTypeV3.UNKNOWN,
+                                    itsUnknownValue1));
+
+        itsUnknownField2 = field2;
+        itsUnknownValue2 = value2;
+        itsHeaderRec.setField(
+                new PwsUnknownField(itsUnknownField2, PwsHeaderTypeV3.UNKNOWN,
+                                    itsUnknownValue2));
+    }
+
+    public void verifyFileHeader(@NonNull PwsFile file)
+    {
+        V3FileInfo fileInfo = new V3FileInfo(file);
+        assertNotNull(itsUuid);
+        assertEquals(itsUuid, fileInfo.itsUuid);
+        assertEquals(itsVersion, fileInfo.itsVersion);
+        assertNotNull(itsLastSaveTime);
+        assertEquals(itsLastSaveTime, fileInfo.itsLastSaveTime);
+        assertNull(itsLastSaveWho);
+        //noinspection ConstantValue
+        assertEquals(itsLastSaveWho, fileInfo.itsLastSaveWho);
+        assertNotNull(itsLastSaveWhat);
+        assertEquals(itsLastSaveWhat, fileInfo.itsLastSaveWhat);
+        assertNotNull(itsLastSaveUser);
+        assertEquals(itsLastSaveUser, fileInfo.itsLastSaveUser);
+        assertNotNull(itsLastSaveHost);
+        assertEquals(itsLastSaveHost, fileInfo.itsLastSaveHost);
+        assertNotNull(itsNamedPasswordPolicies);
+        assertEquals(itsNamedPasswordPolicies,
+                     fileInfo.itsNamedPasswordPolicies);
+        assertNotNull(itsYubico);
+        assertEquals(itsYubico, fileInfo.itsYubico);
+        assertNotNull(itsLastPasswordChange);
+        assertEquals(itsLastPasswordChange, fileInfo.itsLastPasswordChange);
+
+        boolean unknown1Verified = false;
+        boolean unknown2Verified = false;
+        for(var headerFieldIter = fileInfo.itsHeaderRec.getFields();
+            headerFieldIter.hasNext(); ) {
+            var headerFieldId = headerFieldIter.next();
+            switch (PwsHeaderTypeV3.fromType(headerFieldId)) {
+            case VERSION,
+                 UUID,
+                 LAST_SAVE_TIME, LAST_SAVE_WHO, LAST_SAVE_WHAT,
+                 LAST_SAVE_USER, LAST_SAVE_HOST, NAMED_PASSWORD_POLICIES,
+                 YUBICO, LAST_PASSWORD_CHANGE -> {
+            }
+            case END_OF_RECORD -> fail();
+            case UNKNOWN -> {
+                var headerField = fileInfo.itsHeaderRec.getField(headerFieldId);
+                if ((itsUnknownField1 != -1) &&
+                    (itsUnknownField1 == headerFieldId)) {
+                    assertTrue(headerField instanceof PwsUnknownField);
+                    assertEquals(itsUnknownField1, headerField.getTypeId());
+                    assertNotNull(itsUnknownValue1);
+                    assertTrue(headerField.getValue() instanceof byte[]);
+                    assertArrayEquals(itsUnknownValue1,
+                                      (byte[])headerField.getValue());
+                    unknown1Verified = true;
+                } else if ((itsUnknownField2 != -1) &&
+                           (itsUnknownField2 == headerFieldId)) {
+                    assertTrue(headerField instanceof PwsUnknownField);
+                    assertEquals(itsUnknownField2, headerField.getTypeId());
+                    assertNotNull(itsUnknownValue2);
+                    assertTrue(headerField.getValue() instanceof byte[]);
+                    assertArrayEquals(itsUnknownValue2,
+                                      (byte[])headerField.getValue());
+                    unknown2Verified = true;
+                } else {
+                    fail();
+                }
+            }
+            }
+        }
+
+        assertEquals(itsUnknownField1 != -1, unknown1Verified);
+        assertEquals(itsUnknownField2 != -1, unknown2Verified);
+    }
+
+    private static PwsRecord getHeaderRec(@NonNull PwsFile file)
+    {
+        assertTrue(file instanceof PwsFileV3);
+        return ((PwsFileV3)file).getHeaderRecord();
+    }
+
+    private static UUID getUuid(@NonNull PwsRecord headerRec)
+    {
+        var uuid = headerRec.getField(PwsHeaderTypeV3.UUID);
+        assertTrue(uuid instanceof PwsUUIDField);
+        assertTrue(uuid.getValue() instanceof UUID);
+        return (UUID)uuid.getValue();
+    }
+
+    @Nullable
+    private String getHeaderStr(@NonNull PwsHeaderTypeV3 field)
+    {
+        var strField = itsHeaderRec.getField(field);
+        if (strField != null) {
+            assertTrue(strField instanceof PwsStringUnicodeField);
+            assertTrue(strField.getValue() instanceof String);
+            return (String)strField.getValue();
+        } else {
+            return null;
+        }
+    }
+
+    @Nullable
+    private Date getHeaderTime(@NonNull PwsHeaderTypeV3 field)
+    {
+        var timeField = itsHeaderRec.getField(field);
+        if (timeField != null) {
+            assertTrue(timeField instanceof PwsTimeField);
+            assertTrue(timeField.getValue() instanceof Date);
+            return (Date)timeField.getValue();
+        } else {
+            return null;
+        }
+    }
+}

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
@@ -1228,7 +1228,8 @@ public class PasswdFileData
             case PASSWORD_LIFETIME: {
                 Date d = (Date)val;
                 if ((d != null) && (d.getTime() != 0)) {
-                    field = new PwsTimeField(fieldId, d);
+                    field = new PwsTimeField(fieldId,
+                                             PwsTimeField.Format.DEFAULT, d);
                 }
                 break;
             }
@@ -1319,7 +1320,9 @@ public class PasswdFileData
                 var modFieldId = (fieldId == PwsFieldTypeV3.PASSWORD) ?
                                  PwsFieldTypeV3.PASSWORD_MOD_TIME :
                                  PwsFieldTypeV3.LAST_MOD_TIME;
-                rec.setField(new PwsTimeField(modFieldId, new Date()));
+                rec.setField(new PwsTimeField(modFieldId,
+                                              PwsTimeField.Format.DEFAULT,
+                                              new Date()));
             }
         }
     }

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
@@ -25,7 +25,6 @@ import com.jefftharris.passwdsafe.util.Pair;
 
 import org.jetbrains.annotations.Contract;
 import org.pwsafe.lib.UUID;
-import org.pwsafe.lib.Util;
 import org.pwsafe.lib.exception.EndOfFileException;
 import org.pwsafe.lib.exception.InvalidPassphraseException;
 import org.pwsafe.lib.exception.RecordLoadException;
@@ -51,11 +50,10 @@ import org.pwsafe.lib.file.PwsStringField;
 import org.pwsafe.lib.file.PwsStringUnicodeField;
 import org.pwsafe.lib.file.PwsTimeField;
 import org.pwsafe.lib.file.PwsUUIDField;
-import org.pwsafe.lib.file.PwsUnknownField;
+import org.pwsafe.lib.file.PwsVersionField;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
@@ -730,16 +728,6 @@ public class PasswdFileData
         return itsPwsFile.getLoadErrors();
     }
 
-    private static int hexBytesToInt(byte[] bytes, int pos, int len)
-    {
-        int i = 0;
-        for (int idx = pos; idx < (pos + len); ++idx) {
-            i <<= 4;
-            i |= Character.digit(bytes[idx], 16);
-        }
-        return i;
-    }
-
     /** Add an observer for file changes */
     public static void addObserver(PasswdFileDataObserver observer)
     {
@@ -1005,19 +993,12 @@ public class PasswdFileData
             case LAST_SAVE_TIME:
             case LAST_PASSWORD_CHANGE: {
                 PwsField time = doGetHeaderField(rec, fieldId);
-                if (time == null) {
+                if ((time instanceof PwsTimeField) &&
+                    (time.getValue() instanceof Date d)) {
+                    return d.toString();
+                } else {
                     return null;
                 }
-                byte[] bytes = time.getBytes();
-                if (bytes.length == 8) {
-                    byte[] binbytes = new byte[4];
-                    Util.putIntToByteArray(binbytes, hexBytesToInt(bytes, 0,
-                                                                   bytes.length),
-                                           0);
-                    bytes = binbytes;
-                }
-                Date d = new Date(Util.getMillisFromByteArray(bytes, 0));
-                return d.toString();
             }
             case LAST_SAVE_USER: {
                 PwsField field = doGetHeaderField(rec, fieldId);
@@ -1066,20 +1047,10 @@ public class PasswdFileData
             switch (fieldId) {
             case LAST_SAVE_TIME:
             case LAST_PASSWORD_CHANGE: {
-                long timeVal = ((Date)value).getTime();
-                byte[] newbytes;
                 int minor = getHdrMinorVersion(rec);
-                if (minor >= 2) {
-                    newbytes = new byte[4];
-                    Util.putMillisToByteArray(newbytes, timeVal, 0);
-                } else {
-                    int secs = (int)(timeVal / 1000);
-                    String str = String.format("%08x", secs);
-                    newbytes = str.getBytes();
-                }
-                rec.setField(new PwsUnknownField(fieldId.getId(),
-                                                 PwsHeaderTypeV3.UNKNOWN,
-                                                 newbytes));
+                var format = (minor >= 2) ? PwsTimeField.Format.DEFAULT :
+                             PwsTimeField.Format.HEADER_ASCII;
+                rec.setField(new PwsTimeField(fieldId, format, (Date)value));
                 break;
             }
             case LAST_SAVE_WHAT:
@@ -1127,33 +1098,22 @@ public class PasswdFileData
     @Nullable
     private static String doHdrFieldToString(@NonNull PwsField field)
     {
-        try {
-            //noinspection CharsetObjectCanBeUsed
-            return new String(field.getBytes(), "UTF-8");
-        }
-        catch (UnsupportedEncodingException e) {
+        if ((field instanceof PwsStringUnicodeField) &&
+            (field.getValue() instanceof String str)) {
+            return str;
+        } else {
             return null;
         }
     }
 
 
     private static void doSetHdrFieldString(PwsRecord rec,
-                                            PwsHeaderTypeV3 fieldId,
+                                            @NonNull PwsHeaderTypeV3 fieldId,
                                             String val)
     {
-        try {
-            PwsField field = null;
-            if (val != null) {
-                //noinspection CharsetObjectCanBeUsed
-                field = new PwsUnknownField(fieldId.getId(),
-                                            PwsHeaderTypeV3.UNKNOWN,
-                                            val.getBytes("UTF-8"));
-            }
-            setOrRemoveField(field, fieldId.getId(), rec);
-        }
-        catch (UnsupportedEncodingException e) {
-            Log.e(TAG, "Invalid encoding", e);
-        }
+        var field = (val != null) ? new PwsStringUnicodeField(fieldId, val) :
+                    null;
+        setOrRemoveField(field, fieldId.getId(), rec);
     }
 
     /** Get a non-header record's field after translating its field
@@ -1487,35 +1447,17 @@ public class PasswdFileData
 
     private static int getHdrMinorVersion(PwsRecord rec)
     {
-        PwsField ver = doGetHeaderField(rec, PwsHeaderTypeV3.VERSION);
-        if (ver == null) {
-            return -1;
-        }
-        byte[] bytes = ver.getBytes();
-        if ((bytes == null) || (bytes.length == 0)) {
-            return -1;
-        }
-        return bytes[0];
+        PwsField field = doGetHeaderField(rec, PwsHeaderTypeV3.VERSION);
+        return (field instanceof PwsVersionField ver) ? ver.getMinor() : -1;
     }
 
     private static void setHdrMinorVersion(PwsRecord rec, byte minor)
     {
-        PwsField ver = doGetHeaderField(rec, PwsHeaderTypeV3.VERSION);
-        if (ver == null) {
-            return;
+        PwsField field = doGetHeaderField(rec, PwsHeaderTypeV3.VERSION);
+        if (field instanceof PwsVersionField ver) {
+            rec.setField(new PwsVersionField(PwsHeaderTypeV3.VERSION,
+                                             ver.getMajor(), minor));
         }
-        byte[] bytes = ver.getBytes();
-        if ((bytes == null) || (bytes.length == 0)) {
-            return;
-        }
-
-        byte[] newbytes = new byte[bytes.length];
-        System.arraycopy(bytes, 0, newbytes, 0, bytes.length);
-        newbytes[0] = minor;
-        PwsField newVer = new PwsUnknownField(PwsHeaderTypeV3.VERSION.getId(),
-                                              PwsHeaderTypeV3.UNKNOWN,
-                                              newbytes);
-        rec.setField(newVer);
     }
 
     @Nullable

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/PasswdFileData.java
@@ -1016,6 +1016,8 @@ public class PasswdFileData
 
                 return getHdrLastSaveWhoField(rec, false);
             }
+            case NON_DEFAULT_PREFS:
+            case TREE_DISPLAY_STATUS:
             case LAST_SAVE_WHO:
             case LAST_SAVE_WHAT:
             case NAMED_PASSWORD_POLICIES: {
@@ -1084,6 +1086,8 @@ public class PasswdFileData
             }
             case VERSION:
             case UUID:
+            case NON_DEFAULT_PREFS:
+            case TREE_DISPLAY_STATUS:
             case LAST_SAVE_WHO:
             case YUBICO:
             case END_OF_RECORD:

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsFileV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsFileV3.java
@@ -68,7 +68,7 @@ public final class PwsFileV3 extends PwsFile
     {
         super();
         setHeaderV3(new PwsFileHeaderV3());
-        headerRecord = new PwsRecordV3(true);
+        headerRecord = new PwsRecordV3(PwsRecord.Type.HEADER);
     }
 
     /**
@@ -278,7 +278,7 @@ public final class PwsFileV3 extends PwsFile
     @Override
     public PwsRecord newRecord()
     {
-        return new PwsRecordV3();
+        return new PwsRecordV3(PwsRecord.Type.RECORD);
     }
 
     public PwsRecord getHeaderRecord()
@@ -297,8 +297,7 @@ public final class PwsFileV3 extends PwsFile
     protected void readExtraHeader()
             throws EndOfFileException, IOException, RecordLoadException
     {
-        //headerRecord = (PwsRecordV3) readRecord();
-        headerRecord = new PwsRecordV3(this, true);
+        headerRecord = new PwsRecordV3(this, PwsRecord.Type.HEADER);
     }
 
     /**

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsHeaderTypeV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsHeaderTypeV3.java
@@ -7,6 +7,8 @@
  */
 package org.pwsafe.lib.file;
 
+import android.util.SparseArray;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
@@ -31,6 +33,14 @@ public enum PwsHeaderTypeV3 implements PwsFieldType
     private final int itsId;
     private final Class<? extends PwsField> itsFieldClass;
 
+    private static final SparseArray<PwsHeaderTypeV3> itsTypesById =
+            new SparseArray<>(PwsHeaderTypeV3.values().length);
+    static {
+        for (var type: PwsHeaderTypeV3.values()) {
+            itsTypesById.append(type.itsId, type);
+        }
+    }
+
     PwsHeaderTypeV3(int id, Class<? extends PwsField> clazz)
     {
         itsId = id;
@@ -46,5 +56,10 @@ public enum PwsHeaderTypeV3 implements PwsFieldType
     public Class<? extends PwsField> getFieldClass()
     {
         return itsFieldClass;
+    }
+
+    public static @NonNull PwsHeaderTypeV3 fromType(int type)
+    {
+        return itsTypesById.get(type, UNKNOWN);
     }
 }

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsHeaderTypeV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsHeaderTypeV3.java
@@ -14,7 +14,7 @@ import androidx.annotation.Nullable;
  */
 public enum PwsHeaderTypeV3 implements PwsFieldType
 {
-    VERSION(0x00, PwsShortField.class),
+    VERSION(0x00, PwsVersionField.class),
     UUID(0x01, PwsUUIDField.class),
     LAST_SAVE_TIME(0x04, PwsTimeField.class),
     LAST_SAVE_WHO(0x05, PwsStringUnicodeField.class),

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsHeaderTypeV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsHeaderTypeV3.java
@@ -18,6 +18,8 @@ public enum PwsHeaderTypeV3 implements PwsFieldType
 {
     VERSION(0x00, PwsVersionField.class),
     UUID(0x01, PwsUUIDField.class),
+    NON_DEFAULT_PREFS(0x02, PwsStringUnicodeField.class),
+    TREE_DISPLAY_STATUS(0x03, PwsStringUnicodeField.class),
     LAST_SAVE_TIME(0x04, PwsTimeField.class),
     LAST_SAVE_WHO(0x05, PwsStringUnicodeField.class),
     LAST_SAVE_WHAT(0x06, PwsStringUnicodeField.class),

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecord.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecord.java
@@ -46,6 +46,15 @@ public abstract class PwsRecord implements Comparable<Object>, Serializable
             PwsRecord.class.getPackage()).getName());
 
     /**
+     * Type of record - header or normal record
+     */
+    public enum Type
+    {
+        HEADER,
+        RECORD
+    }
+
+    /**
      * The default character set used for <code>byte[]</code> to
      * <code>String</code> conversions.
      */
@@ -54,8 +63,7 @@ public abstract class PwsRecord implements Comparable<Object>, Serializable
     private boolean modified = false;
     private boolean isLoaded = false;
     protected final Map<Integer, PwsField> attributes = new TreeMap<>();
-
-    protected boolean ignoreFieldTypes = false;
+    protected final Type itsType;
 
     /**
      * A holder class for all the data about a single field. It holds the
@@ -186,10 +194,13 @@ public abstract class PwsRecord implements Comparable<Object>, Serializable
 
     /**
      * Simple constructor. Used when creating a new record to add to a file.
+     *
+     * @param type The type of record
      */
-    PwsRecord()
+    PwsRecord(@NonNull Type type)
     {
         super();
+        itsType = type;
     }
 
     /**
@@ -198,50 +209,16 @@ public abstract class PwsRecord implements Comparable<Object>, Serializable
      *
      * @param owner      the file that data is to be read from and which
      *                   "owns" this record.
+     * @param type The type of record
      */
-    PwsRecord(PwsFile owner)
+    PwsRecord(PwsFile owner, @NonNull Type type)
             throws EndOfFileException, IOException, RecordLoadException
     {
-        super();
+        this(type);
 
         loadRecord(owner);
 
         isLoaded = true;
-    }
-
-    /**
-     * Special constructor for use when ignoring field types.
-     *
-     * @param owner            the file that data is to be read from and
-     *                         which "owns" this record.
-     * @param ignoreFieldTypes true if all fields types should be ignored,
-     *                                false otherwise
-     */
-    protected PwsRecord(PwsFile owner, boolean ignoreFieldTypes)
-            throws EndOfFileException, IOException, RecordLoadException
-    {
-        super();
-
-        this.ignoreFieldTypes = ignoreFieldTypes;
-
-        loadRecord(owner);
-
-        isLoaded = true;
-
-    }
-
-    /**
-     * Special constructor for use when ignoring field types.
-     *
-     * @param ignoreFieldTypes true if all fields types should be ignored,
-     *                         false otherwise
-     */
-    protected PwsRecord(
-            @SuppressWarnings("SameParameterValue") boolean ignoreFieldTypes)
-    {
-        super();
-
-        this.ignoreFieldTypes = ignoreFieldTypes;
     }
 
     // *************************************************************************
@@ -392,7 +369,7 @@ public abstract class PwsRecord implements Comparable<Object>, Serializable
             return new PwsRecordV2(file);
         }
         case V3 -> {
-            return new PwsRecordV3(file);
+            return new PwsRecordV3(file, Type.RECORD);
         }
         }
 
@@ -425,35 +402,35 @@ public abstract class PwsRecord implements Comparable<Object>, Serializable
     public void setField(@NonNull PwsField value)
     {
         int typeId = value.getTypeId();
-
-        if (ignoreFieldTypes) {
+        switch (itsType) {
+        case HEADER -> {
             attributes.put(typeId, value);
             setModified();
-            return;
         }
+        case RECORD -> {
+            var fieldType = getFieldType(typeId);
+            if (fieldType != null) {
+                Class<? extends PwsField> cl = value.getClass();
+                var fieldClass = fieldType.getFieldClass();
 
-        var fieldType = getFieldType(typeId);
-        if (fieldType != null) {
-            Class<? extends PwsField> cl = value.getClass();
-            var fieldClass = fieldType.getFieldClass();
+                if (cl == fieldClass) {
+                    attributes.put(typeId, value);
+                    setModified();
+                    return;
+                }
+            }
 
-            if (cl == fieldClass) {
+            // before giving up, check if unknown fields are allowed
+            if (allowUnknownFieldTypes()) {
+                LOG.warn("Adding unknown field of type " + typeId + ", class " +
+                         value.getClass() +
+                         " - maybe a new version is needed?");
                 attributes.put(typeId, value);
                 setModified();
-                return;
+            } else {
+                throw new IllegalArgumentException("Invalid type: " + typeId);
             }
         }
-
-        // before giving up, check if unknown fields are allowed
-        if (allowUnknownFieldTypes()) {
-            LOG.warn("Adding unknown field of type " + typeId +
-                     ", class " + value.getClass() +
-                     " - maybe a new version is needed?");
-            attributes.put(typeId, value);
-            setModified();
-        } else {
-            throw new IllegalArgumentException(
-                    "Invalid type: " + typeId);
         }
     }
 

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecord.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecord.java
@@ -62,7 +62,7 @@ public abstract class PwsRecord implements Comparable<Object>, Serializable
 
     private boolean modified = false;
     private boolean isLoaded = false;
-    protected final Map<Integer, PwsField> attributes = new TreeMap<>();
+    private final Map<Integer, PwsField> attributes = new TreeMap<>();
     protected final Type itsType;
 
     /**
@@ -402,35 +402,26 @@ public abstract class PwsRecord implements Comparable<Object>, Serializable
     public void setField(@NonNull PwsField value)
     {
         int typeId = value.getTypeId();
-        switch (itsType) {
-        case HEADER -> {
-            attributes.put(typeId, value);
-            setModified();
-        }
-        case RECORD -> {
-            var fieldType = getFieldType(typeId);
-            if (fieldType != null) {
-                Class<? extends PwsField> cl = value.getClass();
-                var fieldClass = fieldType.getFieldClass();
+        var fieldType = getFieldType(typeId);
+        if (fieldType != null) {
+            Class<? extends PwsField> cl = value.getClass();
+            var fieldClass = fieldType.getFieldClass();
 
-                if (cl == fieldClass) {
-                    attributes.put(typeId, value);
-                    setModified();
-                    return;
-                }
-            }
-
-            // before giving up, check if unknown fields are allowed
-            if (allowUnknownFieldTypes()) {
-                LOG.warn("Adding unknown field of type " + typeId + ", class " +
-                         value.getClass() +
-                         " - maybe a new version is needed?");
+            if (cl == fieldClass) {
                 attributes.put(typeId, value);
                 setModified();
-            } else {
-                throw new IllegalArgumentException("Invalid type: " + typeId);
+                return;
             }
         }
+
+        // before giving up, check if unknown fields are allowed
+        if (allowUnknownFieldTypes()) {
+            LOG.warn("Adding unknown field of type " + typeId + ", class " +
+                     value.getClass() + " - maybe a new version is needed?");
+            attributes.put(typeId, value);
+            setModified();
+        } else {
+            throw new IllegalArgumentException("Invalid type: " + typeId);
         }
     }
 

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV1.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV1.java
@@ -61,7 +61,7 @@ public class PwsRecordV1 extends PwsRecord implements Comparable<Object>
      */
     PwsRecordV1()
     {
-        super();
+        super(Type.RECORD);
 
         // Set default values
         setField(new PwsStringField(PwsFieldTypeV1.TITLE, ""));
@@ -81,7 +81,7 @@ public class PwsRecordV1 extends PwsRecord implements Comparable<Object>
     PwsRecordV1(PwsFile file)
             throws EndOfFileException, IOException, RecordLoadException
     {
-        super(file);
+        super(file, Type.RECORD);
     }
 
     /**

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV2.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV2.java
@@ -34,7 +34,7 @@ public class PwsRecordV2 extends PwsRecord
      */
     PwsRecordV2()
     {
-        super();
+        super(Type.RECORD);
 
         setField(new PwsUUIDField(PwsFieldTypeV2.UUID, new UUID()));
         setField(new PwsStringField(PwsFieldTypeV2.TITLE, ""));
@@ -51,7 +51,7 @@ public class PwsRecordV2 extends PwsRecord
     PwsRecordV2(PwsFile file)
             throws EndOfFileException, IOException, RecordLoadException
     {
-        super(file);
+        super(file, Type.RECORD);
     }
 
     /**

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
@@ -82,7 +82,8 @@ public class PwsRecordV3 extends PwsRecord
             setField(new PwsUUIDField(PwsFieldTypeV3.UUID, new UUID()));
             setField(new PwsStringUnicodeField(PwsFieldTypeV3.TITLE, ""));
             setField(new PwsPasswdUnicodeField(PwsFieldTypeV3.PASSWORD));
-            setField(new PwsTimeField(PwsFieldTypeV3.CREATION_TIME, new Date()));
+            setField(new PwsTimeField(PwsFieldTypeV3.CREATION_TIME,
+                                      PwsTimeField.Format.DEFAULT, new Date()));
         }
         }
     }

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
@@ -267,11 +267,32 @@ public class PwsRecordV3 extends PwsRecord
                 PwsField itemVal = null;
                 switch (itsType) {
                 case HEADER -> {
-                    // header record has no valid types...
-                    itemVal = new PwsUnknownField(itemType,
-                                                  PwsHeaderTypeV3.UNKNOWN,
-                                                  item.getByteData());
-                    attributes.put(item.getType(), itemVal);
+                    var type = PwsHeaderTypeV3.fromType(itemType);
+                    switch (type) {
+                    case VERSION -> itemVal =
+                            new PwsVersionField(type, item.getByteData());
+                    case UUID -> itemVal =
+                            new PwsUUIDField(type, item.getByteData());
+                    case LAST_SAVE_TIME,
+                         LAST_PASSWORD_CHANGE -> itemVal =
+                            new PwsTimeField(type, item.getByteData());
+                    case LAST_SAVE_WHO,
+                         LAST_SAVE_WHAT,
+                         LAST_SAVE_USER,
+                         LAST_SAVE_HOST,
+                         NAMED_PASSWORD_POLICIES,
+                         YUBICO -> itemVal =
+                            new PwsStringUnicodeField(type, item.getByteData());
+                    case END_OF_RECORD,
+                         UNKNOWN -> {
+                    }
+                    }
+                    if (itemVal == null) {
+                        itemVal = new PwsUnknownField(itemType,
+                                                      PwsHeaderTypeV3.UNKNOWN,
+                                                      item.getByteData());
+                    }
+                    setField(itemVal);
                 }
                 case RECORD -> {
                     var type = PwsFieldTypeV3.fromType(itemType);
@@ -389,7 +410,15 @@ public class PwsRecordV3 extends PwsRecord
     @Override
     protected PwsFieldType getFieldType(int typeId)
     {
-        return PwsFieldTypeV3.fromType(typeId);
+        switch (itsType) {
+        case HEADER -> {
+            return PwsHeaderTypeV3.fromType(typeId);
+        }
+        case RECORD -> {
+            return PwsFieldTypeV3.fromType(typeId);
+        }
+        }
+        return null;
     }
 
     /**

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
@@ -276,7 +276,9 @@ public class PwsRecordV3 extends PwsRecord
                     case LAST_SAVE_TIME,
                          LAST_PASSWORD_CHANGE -> itemVal =
                             new PwsTimeField(type, item.getByteData());
-                    case LAST_SAVE_WHO,
+                    case NON_DEFAULT_PREFS,
+                         TREE_DISPLAY_STATUS,
+                         LAST_SAVE_WHO,
                          LAST_SAVE_WHAT,
                          LAST_SAVE_USER,
                          LAST_SAVE_HOST,

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsRecordV3.java
@@ -65,62 +65,41 @@ public class PwsRecordV3 extends PwsRecord
 
     /**
      * Create a new record with all mandatory fields given their default value.
-     */
-    PwsRecordV3()
-    {
-        super();
-
-        setField(new PwsUUIDField(PwsFieldTypeV3.UUID, new UUID()));
-        setField(new PwsStringUnicodeField(PwsFieldTypeV3.TITLE, ""));
-        setField(new PwsPasswdUnicodeField(PwsFieldTypeV3.PASSWORD));
-        setField(new PwsTimeField(PwsFieldTypeV3.CREATION_TIME, new Date()));
-    }
-
-    /**
-     * A special version for header records
      *
-     * @param ignoredIsHeader Marker for header record
-     * @noinspection SameParameterValue
+     * @param type The type of record
      */
-    PwsRecordV3(boolean ignoredIsHeader)
+    PwsRecordV3(@NonNull Type type)
     {
-        super(true);
-        setField(new PwsVersionField(PwsHeaderTypeV3.VERSION,
-                                     new byte[]{DB_FMT_MINOR_VERSION, 3}));
-        setField(new PwsUUIDField(PwsHeaderTypeV3.UUID, new UUID()));
+        super(type);
+
+        switch (type) {
+        case HEADER -> {
+            setField(new PwsUUIDField(PwsHeaderTypeV3.UUID, new UUID()));
+            setField(new PwsVersionField(PwsHeaderTypeV3.VERSION,
+                                         new byte[]{DB_FMT_MINOR_VERSION, 3}));
+        }
+        case RECORD -> {
+            setField(new PwsUUIDField(PwsFieldTypeV3.UUID, new UUID()));
+            setField(new PwsStringUnicodeField(PwsFieldTypeV3.TITLE, ""));
+            setField(new PwsPasswdUnicodeField(PwsFieldTypeV3.PASSWORD));
+            setField(new PwsTimeField(PwsFieldTypeV3.CREATION_TIME, new Date()));
+        }
+        }
     }
 
     /**
      * Create a new record by reading it from <code>file</code>.
      *
      * @param file the file to read data from.
+     * @param type The type of record
      *
      * @throws EndOfFileException If end of file is reached
      * @throws IOException If a read error occurs.
      */
-    PwsRecordV3(PwsFile file)
+    PwsRecordV3(PwsFile file, @NonNull Type type)
             throws EndOfFileException, IOException, RecordLoadException
     {
-        super(file);
-    }
-
-    /**
-     * A special version which reads and ignores all headers since they have
-     * different ids to standard types.
-     *
-     * @param file the file to read data from.
-     * @param ignoreFieldTypes true if all fields types should be ignored, false
-     * otherwise
-     *
-     * @throws EndOfFileException If end of file is reached
-     * @throws IOException If a read error occurs.
-     */
-    PwsRecordV3(PwsFile file,
-                @SuppressWarnings("SameParameterValue")
-                boolean ignoreFieldTypes)
-            throws EndOfFileException, IOException, RecordLoadException
-    {
-        super(file, ignoreFieldTypes);
+        super(file, type);
     }
 
     /**
@@ -285,13 +264,15 @@ public class PwsRecordV3 extends PwsRecord
                 }
 
                 PwsField itemVal = null;
-                if (ignoreFieldTypes) {
+                switch (itsType) {
+                case HEADER -> {
                     // header record has no valid types...
                     itemVal = new PwsUnknownField(itemType,
                                                   PwsHeaderTypeV3.UNKNOWN,
                                                   item.getByteData());
                     attributes.put(item.getType(), itemVal);
-                } else {
+                }
+                case RECORD -> {
                     var type = PwsFieldTypeV3.fromType(itemType);
                     switch (type) {
                     case V3_ID_STRING:
@@ -358,6 +339,7 @@ public class PwsRecordV3 extends PwsRecord
                                                       item.getByteData());
                     }
                     setField(itemVal);
+                }
                 }
             } catch (EndOfFileException eof) {
                 if (itemErrors != null) {

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsTimeField.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsTimeField.java
@@ -11,6 +11,7 @@ package org.pwsafe.lib.file;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.jetbrains.annotations.Contract;
 import org.pwsafe.lib.Util;
 
 import java.io.Serial;
@@ -24,6 +25,16 @@ public class PwsTimeField extends PwsField
     @Serial
     private static final long serialVersionUID = -3091539688166386331L;
 
+    public enum Format
+    {
+        /// 32-bit, little-endian seconds since epoch
+        DEFAULT,
+        /// Early 8 byte hex string of seconds since epoch for header fields
+        HEADER_ASCII
+    }
+
+    private final Format itsFormat;
+
     /**
      * Constructor
      *
@@ -32,7 +43,8 @@ public class PwsTimeField extends PwsField
      */
     public PwsTimeField(PwsFieldType type, byte[] value)
     {
-        super(type, new Date(Util.getMillisFromByteArray(value, 0)));
+        super(type, createDateFromBytes(value));
+        itsFormat = formatFromBytes(value);
     }
 
     /**
@@ -42,9 +54,10 @@ public class PwsTimeField extends PwsField
      * @param aDate the field's value.
      */
     @SuppressWarnings("SameParameterValue")
-    public PwsTimeField(PwsFieldType type, Date aDate)
+    public PwsTimeField(PwsFieldType type, Format format, Date aDate)
     {
         super(type, normalizeDate(aDate));
+        itsFormat = format;
     }
 
     /**
@@ -57,6 +70,16 @@ public class PwsTimeField extends PwsField
     public byte[] getBytes()
     {
         long value = ((Date)getValue()).getTime();
+
+        switch (itsFormat) {
+        case DEFAULT -> {
+        }
+        case HEADER_ASCII -> {
+            int secs = (int)(value / 1000);
+            String str = String.format("%08x", secs);
+            return str.getBytes();
+        }
+        }
 
         // Force a size of 4, otherwise it would be set to a size of
         // blocklength
@@ -115,5 +138,49 @@ public class PwsTimeField extends PwsField
         long value = date.getTime();
         value -= (value % 1000);
         return new Date(value);
+    }
+
+    /**
+     * Get the time format from its bytes value
+     */
+    @NonNull
+    private static Format formatFromBytes(@NonNull byte[] value)
+    {
+        if (value.length == 8) {
+            return Format.HEADER_ASCII;
+        }
+        return Format.DEFAULT;
+    }
+
+    /**
+     * Create a date value from its bytes value
+     */
+    @Contract("_ -> new")
+    @NonNull
+    private static Date createDateFromBytes(@NonNull byte[] value)
+    {
+        switch (formatFromBytes(value)) {
+        case DEFAULT -> {
+        }
+        case HEADER_ASCII -> {
+            byte[] binbytes = new byte[4];
+            Util.putIntToByteArray(binbytes, hexBytesToInt(value), 0);
+            value = binbytes;
+        }
+        }
+        return new Date(Util.getMillisFromByteArray(value, 0));
+    }
+
+    /**
+     * Convert hex bytes to an integer
+     */
+    private static int hexBytesToInt(@NonNull byte[] bytes)
+    {
+        int i = 0;
+        for (byte aByte : bytes) {
+            i <<= 4;
+            i |= Character.digit(aByte, 16);
+        }
+        return i;
     }
 }

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsTimeField.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsTimeField.java
@@ -130,7 +130,7 @@ public class PwsTimeField extends PwsField
      * a file
      */
     @Nullable
-    private static Date normalizeDate(Date date)
+    public static Date normalizeDate(Date date)
     {
         if (date == null) {
             return null;

--- a/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsVersionField.java
+++ b/passwdsafe/src/main/java/org/pwsafe/lib/file/PwsVersionField.java
@@ -35,6 +35,30 @@ public class PwsVersionField extends PwsIntegerField
     }
 
     /**
+     * Constructor
+     */
+    public PwsVersionField(PwsFieldType type, int major, int minor)
+    {
+        super(type, new byte[]{0, 0, (byte)minor, (byte)major});
+    }
+
+    /**
+     * Get the major version number
+     */
+    public int getMajor()
+    {
+        return (getValue() instanceof Integer i) ? ((i >> 24) & 0xff) : -1;
+    }
+
+    /**
+     * Get the minor version number
+     */
+    public int getMinor()
+    {
+        return (getValue() instanceof Integer i) ? ((i >> 16) & 0xff) : -1;
+    }
+
+    /**
      * Returns this integer as an array of bytes.  The returned array will
      * have
      * a length of PwsFile.BLOCK_LENGTH and is thus suitable to be written


### PR DESCRIPTION
Use the PwsHeaderTypeV3 enum for header fields.  Load and verify fields using the enum and the appropriate typed fields instead of unknown.

Addresses: #14
