### PR TITLE
passwdsafe: LauncherRecordShortcuts: Cleanup file data view properly

### DIFF
--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/LauncherRecordShortcuts.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/LauncherRecordShortcuts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -152,6 +152,7 @@ public class LauncherRecordShortcuts extends DialogActivity
         SharedPreferences prefs = Preferences.getSharedPrefs(this);
         prefs.unregisterOnSharedPreferenceChangeListener(this);
         itsFileDataView.onDetach();
+        itsFileDataView.onDestroy();
         super.onDestroy();
     }
 


### PR DESCRIPTION
Both detach and destroy the file data view to ensure it is fully cleaned-up. Otherwise, the held filter may not be closed resulting in finalizer logging.