### PR TITLE
passwdsafe, sync: Use activity result contracts, menu provider, and listener-specific dialog keys

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -17,6 +17,20 @@
             </InsightsFilterSettings>
           </value>
         </entry>
+        <entry key="Android vitals">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="com.jefftharris.passwdsafe" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="SEVEN_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
         <entry key="Firebase Crashlytics">
           <value>
             <InsightsFilterSettings>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -5,7 +5,7 @@
         <option name="TAB_SIZE" value="8" />
       </value>
     </option>
-    <option name="LINE_SEPARATOR" value="&#10;" />
+    <option name="LINE_SEPARATOR" />
     <option name="FIELD_NAME_PREFIX" value="its" />
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -48,6 +48,7 @@
       <option name="ignoredTypes">
         <set>
           <option value="java.lang.CharSequence" />
+          <option value="java.lang.StringBuilder" />
         </set>
       </option>
     </inspection_tool>

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
+        classpath 'com.android.tools.build:gradle:9.1.1'
 
         // From https://github.com/google/secrets-gradle-plugin
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,3 +33,13 @@ android.nonFinalResIds=true
 # org.gradle.parallel=true
 
 android.jetifier.ignorelist = jackson-core, fastdoubleparser
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -42,10 +42,11 @@ android {
 }
 
 dependencies {
-    api 'androidx.annotation:annotation:1.9.1'
+    api 'androidx.annotation:annotation:1.10.0'
     api 'androidx.appcompat:appcompat:1.7.1'
     api 'androidx.cardview:cardview:1.0.0'
     api 'androidx.constraintlayout:constraintlayout:2.2.1'
+    // NOTE: 1.18.0+ required min SDK version update
     api 'androidx.core:core:1.17.0'
     api 'androidx.fragment:fragment:1.8.9'
     api 'androidx.gridlayout:gridlayout:1.1.0'
@@ -62,5 +63,5 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.22"))
 
     // Extra IDE annotations from Jetbrains, e.g @PrintFormat
-    implementation 'org.jetbrains:annotations:26.0.2-1'
+    implementation 'org.jetbrains:annotations:26.1.0'
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,6 @@ android {
     compileSdk = 36
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 36
         vectorDrawables.useSupportLibrary = true
         buildConfigField 'String', 'BUILD_ID', "\"${buildId()}\""
         buildConfigField 'String', 'BUILD_DATE', "\"${buildTime()}\""
@@ -33,6 +32,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
     productFlavors {
+    }
+    lint {
+        targetSdk = 36
+    }
+    testOptions {
+        targetSdk = 36
     }
 }
 

--- a/passwdsafe/build.gradle
+++ b/passwdsafe/build.gradle
@@ -82,7 +82,7 @@ android {
 
 dependencies {
     def room_version = "2.7.1"
-    def yubikey_version = "3.0.0"
+    def yubikey_version = "3.1.0"
     def espresso_version = "3.7.0"
 
     implementation fileTree(include: ['*.jar'], dir: 'libs')
@@ -98,7 +98,7 @@ dependencies {
 
     annotationProcessor "androidx.room:room-compiler:$room_version"
 
-    implementation 'commons-codec:commons-codec:1.20.0'
+    implementation 'commons-codec:commons-codec:1.21.0'
 
     // Core library
     androidTestImplementation 'androidx.test:core:1.7.0'

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/BackupFilesFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/BackupFilesFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2020-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2020-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -73,6 +73,7 @@ public class BackupFilesFragment extends Fragment
     private Listener itsListener;
     private BackupFilesModel itsBackupFiles;
     private BackupFilesAdapter itsBackupFilesAdapter;
+    private ConfirmPromptDialog.Client itsConfirmDlg;
     private SelectionKeyProvider itsKeyProvider;
     private SelectionTracker<Long> itsSelTracker;
     private ActionMode itsActionMode;
@@ -106,7 +107,7 @@ public class BackupFilesFragment extends Fragment
         itsBackupFiles = new ViewModelProvider(requireActivity())
                 .get(BackupFilesModel.class);
 
-        ConfirmPromptDialog.setListener(this);
+        itsConfirmDlg = new ConfirmPromptDialog.Client(this, TAG);
     }
 
     @Override
@@ -226,8 +227,7 @@ public class BackupFilesFragment extends Fragment
     public void onFragmentResult(@NonNull String requestKey,
                                  @NonNull Bundle result)
     {
-        switch (requestKey) {
-        case ConfirmPromptDialog.REQUEST_KEY -> {
+        if (itsConfirmDlg.checkKey(requestKey)) {
             var action = Utils.getEnum(ConfirmAction.class, CONFIRM_ARG_ACTION,
                                        result);
             if (action != null) {
@@ -236,7 +236,6 @@ public class BackupFilesFragment extends Fragment
                 case DELETE_SELECTED -> onConfirmDeleteSelected();
                 }
             }
-        }
         }
     }
 
@@ -327,9 +326,7 @@ public class BackupFilesFragment extends Fragment
 
         Bundle confirmArgs = new Bundle();
         confirmArgs.putString(CONFIRM_ARG_ACTION, action.name());
-        ConfirmPromptDialog dialog = ConfirmPromptDialog.newInstance(
-                title, null, confirm, confirmArgs);
-        dialog.show(getParentFragmentManager(), "prompt");
+        itsConfirmDlg.show(title, null, confirm, confirmArgs);
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/NotificationMgr.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/NotificationMgr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -24,7 +24,6 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.collection.LongSparseArray;
-import androidx.fragment.app.DialogFragment;
 
 import com.jefftharris.passwdsafe.file.PasswdExpiration;
 import com.jefftharris.passwdsafe.file.PasswdExpiryFilter;
@@ -161,15 +160,17 @@ public class NotificationMgr implements PasswdFileDataObserver
     }
 
     /**
-     * Create a confirm prompt for clearing all notifications
+     * Show a confirmation prompt for clearing all notifications
      */
-    public DialogFragment createClearAllPrompt(@NonNull Context ctx,
-                                               Bundle args)
+    public void showClearAllPrompt(
+            @NonNull ConfirmPromptDialog.Client confirmDlg,
+            @NonNull Context ctx,
+            Bundle args)
     {
-        return ConfirmPromptDialog.newInstance(
-                ctx.getString(R.string.clear_password_notifications),
-                ctx.getString(R.string.erase_all_expiration_notifications),
-                ctx.getString(R.string.clear), args);
+        confirmDlg.show(ctx.getString(R.string.clear_password_notifications),
+                        ctx.getString(
+                                R.string.erase_all_expiration_notifications),
+                        ctx.getString(R.string.clear), args);
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -236,6 +236,9 @@ public class PasswdSafe extends AppCompatActivity
     /** Currently running tasks */
     private final ManagedTasks itsTasks = new ManagedTasks();
 
+    /** Confirm prompt dialog */
+    private ConfirmPromptDialog.Client itsConfirmDlg;
+
     /** Used to store the last screen title */
     private CharSequence itsTitle;
 
@@ -309,7 +312,7 @@ public class PasswdSafe extends AppCompatActivity
         expiryClearBtn.setOnClickListener(this);
         itsExpiry = findViewById(R.id.expiry);
 
-        ConfirmPromptDialog.setListener(this);
+        itsConfirmDlg = new ConfirmPromptDialog.Client(this, TAG);
 
         FragmentManager fragMgr = getSupportFragmentManager();
         itsFileDataFrag = (PasswdSafeFileDataFragment)
@@ -637,11 +640,9 @@ public class PasswdSafe extends AppCompatActivity
             Bundle confirmArgs = new Bundle();
             confirmArgs.putString(CONFIRM_ARG_ACTION,
                                   ConfirmAction.RESTORE_FILE.name());
-            ConfirmPromptDialog dialog = ConfirmPromptDialog.newInstance(
-                    getString(R.string.restore_file_p, backup.title,
-                              Utils.formatDate(backup.date, this)),
-                    null, getString(R.string.restore), confirmArgs);
-            dialog.show(getSupportFragmentManager(), "Restore file");
+            itsConfirmDlg.show(getString(R.string.restore_file_p, backup.title,
+                                         Utils.formatDate(backup.date, this)),
+                               null, getString(R.string.restore), confirmArgs);
             return true;
         } else if (itemId == R.id.menu_close) {
             checkNavigation(false, this::finish);
@@ -661,10 +662,8 @@ public class PasswdSafe extends AppCompatActivity
             Bundle confirmArgs = new Bundle();
             confirmArgs.putString(CONFIRM_ARG_ACTION,
                                   ConfirmAction.DELETE_FILE.name());
-            ConfirmPromptDialog dialog = ConfirmPromptDialog.newInstance(
-                    getString(R.string.delete_file_msg, uriName),
-                    null, getString(R.string.delete), confirmArgs);
-            dialog.show(getSupportFragmentManager(), "Delete file");
+            itsConfirmDlg.show(getString(R.string.delete_file_msg, uriName),
+                               null, getString(R.string.delete), confirmArgs);
             return true;
         } else if (itemId == R.id.menu_file_protect_records) {
             protectRecords(true);
@@ -968,12 +967,10 @@ public class PasswdSafe extends AppCompatActivity
             Bundle enableArgs = new Bundle();
             enableArgs.putString(CONFIRM_ARG_ACTION,
                                  ConfirmAction.SHOW_ENABLE_KEYBOARD.name());
-            ConfirmPromptDialog dialog = ConfirmPromptDialog.newInstance(
-                    getString(R.string.copy_password),
-                    getString(R.string.copy_password_warning),
-                    getString(android.R.string.copy), confirmArgs,
-                    getString(R.string.enable), enableArgs);
-            dialog.show(getSupportFragmentManager(), "Copy password");
+            itsConfirmDlg.show(getString(R.string.copy_password),
+                               getString(R.string.copy_password_warning),
+                               getString(android.R.string.copy), confirmArgs,
+                               getString(R.string.enable), enableArgs);
             return;
         }
         case TOTP: {
@@ -1080,10 +1077,8 @@ public class PasswdSafe extends AppCompatActivity
         confirmArgs.putString(CONFIRM_ARG_ACTION,
                               ConfirmAction.DELETE_RECORD.name());
         confirmArgs.putParcelable(CONFIRM_ARG_LOCATION, location);
-        ConfirmPromptDialog dialog = ConfirmPromptDialog.newInstance(
-                getString(R.string.delete_record_msg, title), null,
-                getString(R.string.delete), confirmArgs);
-        dialog.show(getSupportFragmentManager(), "Delete record");
+        itsConfirmDlg.show(getString(R.string.delete_record_msg, title), null,
+                           getString(R.string.delete), confirmArgs);
     }
 
     @Override
@@ -1198,11 +1193,9 @@ public class PasswdSafe extends AppCompatActivity
         Bundle confirmArgs = new Bundle();
         confirmArgs.putString(CONFIRM_ARG_ACTION,
                               ConfirmAction.SHARE_FILE.name());
-        ConfirmPromptDialog dialog = ConfirmPromptDialog.newInstance(
-                getString(R.string.share_file_p),
-                getString(R.string.share_file_msg),
-                getString(R.string.share), confirmArgs);
-        dialog.show(getSupportFragmentManager(), "Share file");
+        itsConfirmDlg.show(getString(R.string.share_file_p),
+                           getString(R.string.share_file_msg),
+                           getString(R.string.share), confirmArgs);
     }
 
     @Override
@@ -1254,8 +1247,7 @@ public class PasswdSafe extends AppCompatActivity
     public void onFragmentResult(@NonNull String requestKey,
                                  @NonNull Bundle result)
     {
-        switch (requestKey) {
-        case ConfirmPromptDialog.REQUEST_KEY -> {
+        if (itsConfirmDlg.checkKey(requestKey)) {
             var action = Utils.getEnum(ConfirmAction.class, CONFIRM_ARG_ACTION,
                                        result);
             if (action != null) {
@@ -1268,7 +1260,6 @@ public class PasswdSafe extends AppCompatActivity
                 case RESTORE_FILE -> onConfirmRestoreFile();
                 }
             }
-        }
         }
     }
 

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeEditRecordFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeEditRecordFragment.java
@@ -9,9 +9,7 @@ package com.jefftharris.passwdsafe;
 
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
@@ -34,6 +32,7 @@ import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentResultListener;
@@ -54,7 +53,9 @@ import com.jefftharris.passwdsafe.lib.view.AbstractTextWatcher;
 import com.jefftharris.passwdsafe.lib.view.GuiUtils;
 import com.jefftharris.passwdsafe.lib.view.TextInputUtils;
 import com.jefftharris.passwdsafe.lib.view.TypefaceUtils;
+import com.jefftharris.passwdsafe.util.Optional;
 import com.jefftharris.passwdsafe.util.Pair;
+import com.jefftharris.passwdsafe.view.ChooseRecordActResultContract;
 import com.jefftharris.passwdsafe.view.DatePickerDialogFragment;
 import com.jefftharris.passwdsafe.view.EditRecordResult;
 import com.jefftharris.passwdsafe.view.NewGroupDialog;
@@ -173,10 +174,8 @@ public class PasswdSafeEditRecordFragment
     private ProgressBar itsTotpProgress;
     private View itsNotesLabel;
     private TextView itsNotes;
-
-    private static final String TAG = "PasswdSafeEditRecordFragment";
-
-    private static final int RECORD_SELECTION_REQUEST = 0;
+    private ActivityResultLauncher<ChooseRecordActResultContract.Args>
+            itsRecordSelectionLauncher;
 
     private static final String STATE_EXPIRY_DATE = "expiryDate";
     private static final String STATE_HISTORY = "history";
@@ -208,6 +207,10 @@ public class PasswdSafeEditRecordFragment
         NewGroupDialog.setListener(this);
         PasswdPolicyEditDialog.setListener(this);
         TimePickerDialogFragment.setListener(this);
+
+        itsRecordSelectionLauncher = registerForActivityResult(
+                new ChooseRecordActResultContract(),
+                this::onChooseRecordResult);
 
         itsTotpViewModel = new ViewModelProvider(this).get(
                 PasswdSafeRecordTotpViewModel.class);
@@ -510,29 +513,10 @@ public class PasswdSafeEditRecordFragment
             }
             historyChanged(true);
         } else if (id == R.id.link_ref) {
-            Intent intent = new Intent(PasswdSafeApp.CHOOSE_RECORD_INTENT,
-                                       requireActivity().getIntent().getData(),
-                                       getContext(),
-                                       LauncherRecordShortcuts.class);
-            // Do not allow mixed alias and shortcut references to a
-            // record to work around a bug in Password Safe that does
-            // not allow both
-            switch (itsRecType) {
-            case NORMAL: {
-                break;
-            }
-            case ALIAS: {
-                intent.putExtra(LauncherRecordShortcuts.FILTER_NO_SHORTCUT,
-                                true);
-                break;
-            }
-            case SHORTCUT: {
-                intent.putExtra(LauncherRecordShortcuts.FILTER_NO_ALIAS, true);
-                break;
-            }
-            }
-
-            startActivityForResult(intent, RECORD_SELECTION_REQUEST);
+            itsRecordSelectionLauncher.launch(
+                    new ChooseRecordActResultContract.Args(
+                            requireActivity().getIntent().getData(),
+                            itsRecType));
         } else if (id == R.id.password_generate) {
             if (itsCurrPolicy != null) {
                 try {
@@ -605,19 +589,6 @@ public class PasswdSafeEditRecordFragment
             selectPolicy(null);
         } else if (id == R.id.expire_choice) {
             updatePasswdExpiryChoice(PasswdExpiration.Type.NEVER);
-        }
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data)
-    {
-        PasswdSafeUtil.dbginfo(TAG, "onActivityResult data: %s", data);
-
-        if ((requestCode == RECORD_SELECTION_REQUEST) &&
-            (resultCode == Activity.RESULT_OK)) {
-            setLinkRefUuid(data.getStringExtra(PasswdSafeApp.RESULT_DATA_UUID));
-        } else {
-            super.onActivityResult(requestCode, resultCode, data);
         }
     }
 
@@ -1171,6 +1142,16 @@ public class PasswdSafeEditRecordFragment
         if (!init) {
             // Clear link on type change in case it is no longer valid
             setLinkRef(null, null);
+        }
+    }
+
+    /**
+     * Handle the result of choosing a record
+     */
+    private void onChooseRecordResult(@Nullable Optional<String> result)
+    {
+        if (result != null) {
+            setLinkRefUuid(result.orElse(null));
         }
     }
 

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeEditRecordFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeEditRecordFragment.java
@@ -104,6 +104,10 @@ public class PasswdSafeEditRecordFragment
     }
 
     private PasswdSafeRecordTotpViewModel itsTotpViewModel;
+    private DatePickerDialogFragment.Client itsDatePickerDlg;
+    private TimePickerDialogFragment.Client itsTimePickerDlg;
+    private NewGroupDialog.Client itsNewGroupDlg;
+    private PasswdPolicyEditDialog.Client itsPasswdPolicyDlg;
     private final Validator itsValidator = new Validator();
     private final TreeSet<String> itsGroups =
             new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
@@ -187,6 +191,8 @@ public class PasswdSafeEditRecordFragment
     private static final int TYPE_ALIAS = 1;
     private static final int TYPE_SHORTCUT = 2;
 
+    private static final String TAG = "PasswdSafeEditRecordFragment";
+
     /**
      * Create a new instance
      */
@@ -203,10 +209,10 @@ public class PasswdSafeEditRecordFragment
     public void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
-        DatePickerDialogFragment.setListener(this);
-        NewGroupDialog.setListener(this);
-        PasswdPolicyEditDialog.setListener(this);
-        TimePickerDialogFragment.setListener(this);
+        itsDatePickerDlg = new DatePickerDialogFragment.Client(this, TAG);
+        itsTimePickerDlg = new TimePickerDialogFragment.Client(this, TAG);
+        itsNewGroupDlg = new NewGroupDialog.Client(this, TAG);
+        itsPasswdPolicyDlg = new PasswdPolicyEditDialog.Client(this, TAG);
 
         itsRecordSelectionLauncher = registerForActivityResult(
                 new ChooseRecordActResultContract(),
@@ -488,18 +494,12 @@ public class PasswdSafeEditRecordFragment
     {
         int id = v.getId();
         if (id == R.id.expire_date_date) {
-            DatePickerDialogFragment picker =
-                    DatePickerDialogFragment.newInstance(
-                            itsExpiryDate.get(Calendar.YEAR),
-                            itsExpiryDate.get(Calendar.MONTH),
-                            itsExpiryDate.get(Calendar.DAY_OF_MONTH));
-            picker.show(getParentFragmentManager(), "datePicker");
+            itsDatePickerDlg.show(itsExpiryDate.get(Calendar.YEAR),
+                                  itsExpiryDate.get(Calendar.MONTH),
+                                  itsExpiryDate.get(Calendar.DAY_OF_MONTH));
         } else if (id == R.id.expire_date_time) {
-            TimePickerDialogFragment picker =
-                    TimePickerDialogFragment.newInstance(
-                            itsExpiryDate.get(Calendar.HOUR_OF_DAY),
-                            itsExpiryDate.get(Calendar.MINUTE));
-            picker.show(getParentFragmentManager(), "timePicker");
+            itsTimePickerDlg.show(itsExpiryDate.get(Calendar.HOUR_OF_DAY),
+                                  itsExpiryDate.get(Calendar.MINUTE));
         } else if (id == R.id.history_addremove) {
             if (itsHistory == null) {
                 itsHistory = new PasswdHistory();
@@ -526,9 +526,7 @@ public class PasswdSafeEditRecordFragment
                 }
             }
         } else if (id == R.id.policy_edit) {
-            var dlg = PasswdPolicyEditDialog.newInstance(itsCurrPolicy, null);
-            dlg.show(getParentFragmentManager(),
-                     PasswdPolicyEditDialog.REQUEST_KEY);
+            itsPasswdPolicyDlg.show(itsCurrPolicy, null);
         } else if (id == R.id.totp_value_row) {
             itsTotpViewModel.updateStateShown(
                     PasswdSafeRecordTotpViewModel.VisibiltyChange.TOGGLE);
@@ -596,12 +594,14 @@ public class PasswdSafeEditRecordFragment
     public void onFragmentResult(@NonNull String requestKey,
                                  @NonNull Bundle result)
     {
-        switch (requestKey) {
-        case DatePickerDialogFragment.REQUEST_KEY -> handleDatePicked(result);
-        case NewGroupDialog.REQUEST_KEY -> handleNewGroup(result);
-        case PasswdPolicyEditDialog.REQUEST_KEY ->
-                handlePolicyEditComplete(result);
-        case TimePickerDialogFragment.REQUEST_KEY -> handleTimePicked(result);
+        if (itsDatePickerDlg.checkKey(requestKey)) {
+            handleDatePicked(result);
+        } else if (itsTimePickerDlg.checkKey(requestKey)) {
+            handleTimePicked(result);
+        } else if (itsNewGroupDlg.checkKey(requestKey)) {
+            handleNewGroup(result);
+        } else if (itsPasswdPolicyDlg.checkKey(requestKey)) {
+            handlePolicyEditComplete(result);
         }
     }
 
@@ -1218,8 +1218,7 @@ public class PasswdSafeEditRecordFragment
             // Set to previous group so rotations don't recreate with the new
             // group item selected
             itsGroup.setSelection(itsPrevGroupPos);
-            NewGroupDialog groupDlg = NewGroupDialog.newInstance();
-            groupDlg.show(getParentFragmentManager(), "NewGroupDialog");
+            itsNewGroupDlg.show();
         } else {
             itsPrevGroupPos = position;
             itsValidator.validate();

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeExpirationsFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeExpirationsFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -66,6 +66,8 @@ public class PasswdSafeExpirationsFragment
 
     private static final String TAG = "PasswdSafeExpirationsFragment";
 
+    private ConfirmPromptDialog.Client itsConfirmDlg;
+    private DatePickerDialogFragment.Client itsDatePickerDlg;
     private CheckBox itsEnableExpiryNotifs;
 
     /**
@@ -82,8 +84,8 @@ public class PasswdSafeExpirationsFragment
     public void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
-        ConfirmPromptDialog.setListener(this);
-        DatePickerDialogFragment.setListener(this);
+        itsConfirmDlg = new ConfirmPromptDialog.Client(this, TAG);
+        itsDatePickerDlg = new DatePickerDialogFragment.Client(this, TAG);
     }
 
     @Override
@@ -128,12 +130,9 @@ public class PasswdSafeExpirationsFragment
         }
         case CUSTOM: {
             Calendar now = Calendar.getInstance();
-            DatePickerDialogFragment picker =
-                    DatePickerDialogFragment.newInstance(
-                            now.get(Calendar.YEAR),
-                            now.get(Calendar.MONTH),
-                            now.get(Calendar.DAY_OF_MONTH));
-            picker.show(getParentFragmentManager(), "datePicker");
+            itsDatePickerDlg.show(now.get(Calendar.YEAR),
+                                  now.get(Calendar.MONTH),
+                                  now.get(Calendar.DAY_OF_MONTH));
             break;
         }
         }
@@ -149,11 +148,10 @@ public class PasswdSafeExpirationsFragment
                 Bundle confirmArgs = new Bundle();
                 confirmArgs.putString(CONFIRM_ARG_ACTION,
                                       ConfirmAction.ENABLE_EXPIRY_NOTIFS.name());
-                ConfirmPromptDialog dialog = ConfirmPromptDialog.newInstance(
-                        getString(R.string.expiration_notifications),
-                        getString(R.string.expiration_notifications_warning),
-                        getString(R.string.enable), confirmArgs);
-                dialog.show(getParentFragmentManager(), "expiry");
+                itsConfirmDlg.show(getString(R.string.expiration_notifications),
+                                   getString(
+                                           R.string.expiration_notifications_warning),
+                                   getString(R.string.enable), confirmArgs);
             } else {
                 setExpiryNotif(false);
             }
@@ -164,8 +162,7 @@ public class PasswdSafeExpirationsFragment
     public void onFragmentResult(@NonNull String requestKey,
                                  @NonNull Bundle result)
     {
-        switch (requestKey) {
-        case ConfirmPromptDialog.REQUEST_KEY -> {
+        if (itsConfirmDlg.checkKey(requestKey)) {
             var action = Utils.getEnum(ConfirmAction.class, CONFIRM_ARG_ACTION,
                                        result);
             if (action != null) {
@@ -175,8 +172,8 @@ public class PasswdSafeExpirationsFragment
             } else {
                 refresh();
             }
-        }
-        case DatePickerDialogFragment.REQUEST_KEY -> handleDatePicked(result);
+        } else if (itsDatePickerDlg.checkKey(requestKey)) {
+            handleDatePicked(result);
         }
     }
 

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeNewFileFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeNewFileFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2024 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -7,7 +7,6 @@
  */
 package com.jefftharris.passwdsafe;
 
-import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -24,6 +23,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -33,13 +33,13 @@ import com.jefftharris.passwdsafe.db.RecentFilesDao;
 import com.jefftharris.passwdsafe.file.PasswdFileData;
 import com.jefftharris.passwdsafe.file.PasswdFileUri;
 import com.jefftharris.passwdsafe.lib.ApiCompat;
-import com.jefftharris.passwdsafe.lib.DocumentsContractCompat;
 import com.jefftharris.passwdsafe.lib.PasswdSafeUtil;
 import com.jefftharris.passwdsafe.lib.view.AbstractTextWatcher;
 import com.jefftharris.passwdsafe.lib.view.GuiUtils;
 import com.jefftharris.passwdsafe.lib.view.TextInputUtils;
 import com.jefftharris.passwdsafe.lib.view.TypefaceUtils;
 import com.jefftharris.passwdsafe.util.CountedBool;
+import com.jefftharris.passwdsafe.view.CreatePsafe3DocActResultContract;
 import com.jefftharris.passwdsafe.view.PasswordVisibilityMenuHandler;
 
 import org.jetbrains.annotations.Contract;
@@ -82,10 +82,9 @@ public class PasswdSafeNewFileFragment
     private final CountedBool itsBackgroundDisable = new CountedBool();
     private final Validator itsValidator = new Validator();
     private boolean itsUseStorage = false;
+    private ActivityResultLauncher<String> itsCreateDocLauncher;
 
     private static final String ARG_URI = "uri";
-
-    private static final int CREATE_DOCUMENT_REQUEST = 0;
 
     private static final String TAG = "PasswdSafeNewFileFrag";
 
@@ -113,6 +112,10 @@ public class PasswdSafeNewFileFragment
             setFileUri(uri);
             setDoResolveOnStart(!itsUseStorage);
         }
+
+        itsCreateDocLauncher = registerForActivityResult(
+                new CreatePsafe3DocActResultContract(),
+                this::onCreatePsafe3DocResult);
     }
 
     @Override
@@ -222,73 +225,13 @@ public class PasswdSafeNewFileFragment
             GuiUtils.setKeyboardVisible(itsPassword, requireContext(), false);
             String fileName = itsFileName.getText().toString();
             if (itsUseStorage) {
-                startActivityForResult(createNewFileIntent(fileName),
-                                       CREATE_DOCUMENT_REQUEST);
+                itsCreateDocLauncher.launch(fileName);
             } else {
                 try (Owner<PwsPassword> passwd =
                              PwsPassword.create(itsPassword.getText())) {
                     startTask(new NewTask(fileName, passwd.pass(), this));
                 }
             }
-        }
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data)
-    {
-        switch (requestCode) {
-        case CREATE_DOCUMENT_REQUEST: {
-            if (resultCode != Activity.RESULT_OK) {
-                cancelFragment(true);
-                break;
-            }
-
-            Context ctx = requireContext();
-            Uri newUri = data.getData();
-            String title = RecentFilesDao.getSafDisplayName(newUri, ctx);
-
-            boolean checkPermissions = isCheckPermissions();
-            if (!checkPermissions && (title == null)) {
-                title = data.getStringExtra("__test_display_name");
-            }
-
-            String error = validateFileName(title);
-            if (error != null) {
-                ContentResolver cr = ctx.getContentResolver();
-                ApiCompat.documentsContractDeleteDocument(cr, newUri);
-                String fileError = getString(R.string.cannot_create_file,
-                                             title);
-                PasswdSafeUtil.showFatalMsg(
-                        String.format("%s - %s", fileError, error),
-                        getActivity());
-                break;
-            }
-
-            if (checkPermissions) {
-                RecentFilesDao.updateOpenedSafFile(
-                        newUri, (Intent.FLAG_GRANT_READ_URI_PERMISSION |
-                                 Intent.FLAG_GRANT_WRITE_URI_PERMISSION),
-                        ctx);
-            }
-
-            if ((newUri != null) && !TextUtils.isEmpty(title)) {
-                RecentFilesDao recentFilesDao =
-                        PasswdSafeDb.get(ctx).accessRecentFiles();
-                try {
-                    recentFilesDao.insertOrUpdate(newUri, title);
-                } catch (Exception e) {
-                    Log.e(TAG, "Error saving recent file: " + newUri, e);
-                }
-            }
-            setFileUri(newUri);
-            itsFileName.setText(title);
-            startResolve();
-            break;
-        }
-        default: {
-            super.onActivityResult(requestCode, resultCode, data);
-            break;
-        }
         }
     }
 
@@ -380,23 +323,56 @@ public class PasswdSafeNewFileFragment
         itsValidator.validate();
     }
 
-    /**
-     * Create the intent for creating a new file document
-     */
-    private static @NonNull Intent createNewFileIntent(String fileName)
+    /** Handle the result of creating a file */
+    private void onCreatePsafe3DocResult(
+            @Nullable CreatePsafe3DocActResultContract.Result result)
     {
-        Intent createIntent = new Intent(
-                DocumentsContractCompat.INTENT_ACTION_CREATE_DOCUMENT);
+        if (result == null) {
+            cancelFragment(true);
+            return;
+        }
 
-        // Filter to only show results that can be "opened", such as
-        // a file (as opposed to a list of contacts or timezones).
-        createIntent.addCategory(Intent.CATEGORY_OPENABLE);
+        Context ctx = requireContext();
+        var newUri = result.uri();
+        String title = RecentFilesDao.getSafDisplayName(newUri, ctx);
 
-        // Create a file with the requested MIME type and name.
-        createIntent.setType(PasswdSafeUtil.MIME_TYPE_PSAFE3);
-        createIntent.putExtra(Intent.EXTRA_TITLE, fileName);
-        return createIntent;
+        boolean checkPermissions = isCheckPermissions();
+        if (!checkPermissions && (title == null)) {
+            title = result.testDisplayName();
+        }
+
+        String error = validateFileName(title);
+        if (error != null) {
+            ContentResolver cr = ctx.getContentResolver();
+            ApiCompat.documentsContractDeleteDocument(cr, newUri);
+            String fileError = getString(R.string.cannot_create_file, title);
+            PasswdSafeUtil.showFatalMsg(
+                    String.format("%s - %s", fileError, error),
+                    getActivity());
+            return;
+        }
+
+        if (checkPermissions) {
+            RecentFilesDao.updateOpenedSafFile(
+                    newUri, (Intent.FLAG_GRANT_READ_URI_PERMISSION |
+                             Intent.FLAG_GRANT_WRITE_URI_PERMISSION),
+                    ctx);
+        }
+
+        if ((newUri != null) && !TextUtils.isEmpty(title)) {
+            RecentFilesDao recentFilesDao =
+                    PasswdSafeDb.get(ctx).accessRecentFiles();
+            try {
+                recentFilesDao.insertOrUpdate(newUri, title);
+            } catch (Exception e) {
+                Log.e(TAG, "Error saving recent file: " + newUri, e);
+            }
+        }
+        setFileUri(newUri);
+        itsFileName.setText(title);
+        startResolve();
     }
+
 
     /**
      * Handle when the new task is finished

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafeOpenFileFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -177,6 +177,7 @@ public class PasswdSafeOpenFileFragment
 
     private PasswdSafeOpenFileViewModel itsOpenModel;
     private YubikeyViewModel itsYubikeyModel;
+    private ConfirmPromptDialog.Client itsConfirmDlg;
 
     private static final String ARG_URI = "uri";
     private static final String ARG_REC_TO_OPEN = "recToOpen";
@@ -224,7 +225,7 @@ public class PasswdSafeOpenFileFragment
                 .getLogTracingData()
                 .observe(this, this::onYubikeyLogTracingChanged);
 
-        ConfirmPromptDialog.setListener(this);
+        itsConfirmDlg = new ConfirmPromptDialog.Client(this, TAG);
     }
 
     @Override
@@ -475,11 +476,10 @@ public class PasswdSafeOpenFileFragment
                     Bundle confirmArgs = new Bundle();
                     confirmArgs.putString(CONFIRM_ARG_ACTION,
                                           ConfirmAction.SAVE_PASSWORD.name());
-                    ConfirmPromptDialog dlg = ConfirmPromptDialog.newInstance(
-                            getString(R.string.save_password_p),
-                            getString(R.string.save_password_warning),
-                            getString(R.string.save), confirmArgs);
-                    dlg.show(fragMgr, "saveConfirm");
+                    itsConfirmDlg.show(getString(R.string.save_password_p),
+                                       getString(
+                                               R.string.save_password_warning),
+                                       getString(R.string.save), confirmArgs);
                 }
             }
         } else if (id == R.id.yubikey) {
@@ -491,8 +491,7 @@ public class PasswdSafeOpenFileFragment
     public void onFragmentResult(@NonNull String requestKey,
                                  @NonNull Bundle result)
     {
-        switch (requestKey) {
-        case ConfirmPromptDialog.REQUEST_KEY -> {
+        if (itsConfirmDlg.checkKey(requestKey)) {
             var action = Utils.getEnum(ConfirmAction.class, CONFIRM_ARG_ACTION,
                                        result);
             if (action != null) {
@@ -503,8 +502,6 @@ public class PasswdSafeOpenFileFragment
                 itsSavePasswdCb.setChecked(false);
             }
         }
-        }
-
     }
 
     private void onConfirmSavePassword()

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafePolicyListFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PasswdSafePolicyListFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2017-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2017-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -70,6 +70,8 @@ public class PasswdSafePolicyListFragment extends ListFragment
 
     private Listener itsListener;
     private HeaderPasswdPolicies itsHdrPolicies;
+    private ConfirmPromptDialog.Client itsConfirmDlg;
+    private PasswdPolicyEditDialog.Client itsPasswdPolicyDlg;
     private boolean itsIsFileReadonly = true;
 
     /**
@@ -93,8 +95,8 @@ public class PasswdSafePolicyListFragment extends ListFragment
     public void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
-        ConfirmPromptDialog.setListener(this);
-        PasswdPolicyEditDialog.setListener(this);
+        itsConfirmDlg = new ConfirmPromptDialog.Client(this, TAG);
+        itsPasswdPolicyDlg = new PasswdPolicyEditDialog.Client(this, TAG);
     }
 
     @Override
@@ -162,15 +164,14 @@ public class PasswdSafePolicyListFragment extends ListFragment
     public void onFragmentResult(@NonNull String requestKey,
                                  @NonNull Bundle result)
     {
-        switch (requestKey) {
-        case ConfirmPromptDialog.REQUEST_KEY -> {
+        if (itsConfirmDlg.checkKey(requestKey)) {
             PasswdPolicy policy = result.getParcelable(CONFIRM_ARG_POLICY);
             if (policy != null) {
                 savePolicies(policy.getName(), null);
             }
         }
-        case PasswdPolicyEditDialog.REQUEST_KEY ->
-                handlePolicyEditComplete(result);
+        else if (itsPasswdPolicyDlg.checkKey(requestKey)) {
+            handlePolicyEditComplete(result);
         }
     }
 
@@ -182,10 +183,9 @@ public class PasswdSafePolicyListFragment extends ListFragment
         PasswdSafeUtil.dbginfo(TAG, "Delete policy: %s", policy);
         Bundle confirmArgs = new Bundle();
         confirmArgs.putParcelable(CONFIRM_ARG_POLICY, policy);
-        ConfirmPromptDialog dialog = ConfirmPromptDialog.newInstance(
+        itsConfirmDlg.show(
                 getString(R.string.delete_policy_msg, policy.getName()), null,
                 getString(R.string.delete), confirmArgs);
-        dialog.show(getParentFragmentManager(), "Delete policy");
     }
 
     /**
@@ -200,9 +200,7 @@ public class PasswdSafePolicyListFragment extends ListFragment
             currPolicies = new ArrayList<>(itsHdrPolicies.getPolicyNames());
         }
 
-        var dlg = PasswdPolicyEditDialog.newInstance(policy, currPolicies);
-        dlg.show(getParentFragmentManager(),
-                 PasswdPolicyEditDialog.REQUEST_KEY);
+        itsPasswdPolicyDlg.show(policy, currPolicies);
     }
 
     private void handlePolicyEditComplete(@NonNull Bundle result)

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PreferencesFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PreferencesFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -10,7 +10,6 @@ package com.jefftharris.passwdsafe;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.net.Uri;
@@ -19,6 +18,7 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
@@ -42,7 +42,9 @@ import com.jefftharris.passwdsafe.pref.PasswdTimeoutPref;
 import com.jefftharris.passwdsafe.pref.RecordFieldSortPref;
 import com.jefftharris.passwdsafe.pref.RecordSortOrderPref;
 import com.jefftharris.passwdsafe.pref.ThemePref;
+import com.jefftharris.passwdsafe.util.Optional;
 import com.jefftharris.passwdsafe.view.ConfirmPromptDialog;
+import com.jefftharris.passwdsafe.view.CreateFileShortcutActResultContract;
 
 import org.pwsafe.lib.file.PwsFile;
 
@@ -70,8 +72,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat
         CLEAR_ALL_NOTIFS,
         CLEAR_ALL_SAVED
     }
-
-    private static final int REQUEST_DEFAULT_FILE = 0;
 
     private static final String CONFIRM_ARG_ACTION = "action";
 
@@ -157,15 +157,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat
     }
 
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data)
-    {
-        if (!itsScreen.onActivityResult(requestCode, resultCode, data))
-        {
-            super.onActivityResult(requestCode, resultCode, data);
-        }
-    }
-
-    @Override
     public void onFragmentResult(@NonNull String requestKey,
                                  @NonNull Bundle result)
     {
@@ -206,16 +197,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat
         implements Preference.OnPreferenceClickListener,
                    SharedPreferences.OnSharedPreferenceChangeListener
     {
-        /**
-         * Handle an activity result
-         * @return true if handled; false otherwise
-         */
-        protected boolean onActivityResult(int requestCode, int resultCode,
-                                           Intent data)
-        {
-            return false;
-        }
-
         /**
          * Handle a confirmed dialog prompt
          */
@@ -314,6 +295,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat
         private final Preference itsDefFilePref;
         private final ListPreference itsFileClosePref;
         private final ListPreference itsFileBackupPref;
+        ActivityResultLauncher<Void> itsCreateFileShortcutLauncher;
 
         /**
          * Constructor
@@ -345,6 +327,10 @@ public class PreferencesFragment extends PreferenceFragmentCompat
                 hidePreference(Preferences.PREF_FILE_DIR);
                 hidePreference(Preferences.PREF_FILE_LEGACY_FILE_CHOOSER);
             }
+
+            itsCreateFileShortcutLauncher = registerForActivityResult(
+                    new CreateFileShortcutActResultContract(),
+                    this::onCreateFileShortcutResult);
         }
 
         @Override
@@ -413,38 +399,23 @@ public class PreferencesFragment extends PreferenceFragmentCompat
         @Override
         public boolean onPreferenceClick(@NonNull Preference preference)
         {
-            switch (preference.getKey()) {
-            case Preferences.PREF_DEF_FILE: {
-                Intent intent = new Intent(Intent.ACTION_CREATE_SHORTCUT, null,
-                                           getContext(),
-                                           LauncherFileShortcuts.class);
-                intent.putExtra(LauncherFileShortcuts.EXTRA_IS_DEFAULT_FILE,
-                                true);
-                startActivityForResult(intent, REQUEST_DEFAULT_FILE);
-                return true;
-            }
-            }
-            return false;
+            return switch (preference.getKey()) {
+                case Preferences.PREF_DEF_FILE -> {
+                    itsCreateFileShortcutLauncher.launch(null);
+                    yield true;
+                }
+                default -> false;
+            };
         }
 
-        @Override
-        public boolean onActivityResult(int requestCode, int resultCode,
-                                        Intent data)
+        /**
+         * Handle the result of choosing a file shortcut
+         */
+        private void onCreateFileShortcutResult(@Nullable Optional<Uri> result)
         {
-            switch (requestCode) {
-            case REQUEST_DEFAULT_FILE: {
-                if (resultCode != Activity.RESULT_OK) {
-                    return true;
-                }
-                Intent val =
-                        data.getParcelableExtra(Intent.EXTRA_SHORTCUT_INTENT);
-                Uri uri = (val != null) ? val.getData() : null;
+            if (result != null) {
+                var uri = result.orElse(null);
                 setDefFilePref((uri != null) ? uri.toString() : null);
-                return true;
-            }
-            default: {
-                return false;
-            }
             }
         }
 

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PreferencesFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/PreferencesFragment.java
@@ -21,7 +21,6 @@ import android.util.Log;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentResultListener;
 import androidx.preference.EditTextPreference;
@@ -79,6 +78,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat
 
     private Listener itsListener;
     private Screen itsScreen;
+    private ConfirmPromptDialog.Client itsConfirmDlg;
 
     /**
      * Create a new instance
@@ -97,7 +97,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat
     public void onCreate(@Nullable Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
-        ConfirmPromptDialog.setListener(this);
+        itsConfirmDlg = new ConfirmPromptDialog.Client(this, TAG);
     }
 
     @Override
@@ -160,14 +160,12 @@ public class PreferencesFragment extends PreferenceFragmentCompat
     public void onFragmentResult(@NonNull String requestKey,
                                  @NonNull Bundle result)
     {
-        switch (requestKey) {
-        case ConfirmPromptDialog.REQUEST_KEY -> {
+        if (itsConfirmDlg.checkKey(requestKey)) {
             var action = Utils.getEnum(ConfirmAction.class, CONFIRM_ARG_ACTION,
                                        result);
             if (action != null) {
                 itsScreen.promptConfirmed(action);
             }
-        }
         }
     }
 
@@ -560,20 +558,19 @@ public class PreferencesFragment extends PreferenceFragmentCompat
                 Bundle confirmArgs = new Bundle();
                 confirmArgs.putString(CONFIRM_ARG_ACTION,
                                       ConfirmAction.CLEAR_ALL_NOTIFS.name());
-                DialogFragment dlg = app.getNotifyMgr().createClearAllPrompt(
-                        act, confirmArgs);
-                dlg.show(getParentFragmentManager(), "clearNotifsConfirm");
+                app
+                        .getNotifyMgr()
+                        .showClearAllPrompt(itsConfirmDlg, act, confirmArgs);
                 return true;
             }
             case Preferences.PREF_PASSWD_CLEAR_ALL_SAVED: {
                 Bundle confirmArgs = new Bundle();
                 confirmArgs.putString(CONFIRM_ARG_ACTION,
                                       ConfirmAction.CLEAR_ALL_SAVED.name());
-                ConfirmPromptDialog dlg = ConfirmPromptDialog.newInstance(
+                itsConfirmDlg.show(
                         getString(R.string.clear_all_saved_passwords),
                         getString(R.string.erase_all_saved_passwords),
                         getString(R.string.clear), confirmArgs);
-                dlg.show(getParentFragmentManager(), "clearSavedConfirm");
                 return true;
             }
             }

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/StorageFileListFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/StorageFileListFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2015-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2015-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -30,6 +30,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.Fragment;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.AsyncTaskLoader;
@@ -57,6 +58,7 @@ import java.util.List;
 public final class StorageFileListFragment extends Fragment
         implements LoaderManager.LoaderCallbacks<Cursor>,
                    View.OnClickListener,
+                   MenuProvider,
                    StorageFileListOps
 {
     /** Listener interface for the owning activity */
@@ -129,7 +131,7 @@ public final class StorageFileListFragment extends Fragment
     {
         boolean hasMenu = itsListener.activityHasMenu();
         if (hasMenu) {
-            setHasOptionsMenu(true);
+            GuiUtils.enableOptionsMenu(this);
         }
 
         View rootView = inflater.inflate(R.layout.fragment_storage_file_list,
@@ -221,15 +223,13 @@ public final class StorageFileListFragment extends Fragment
     }
 
     @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu,
-                                    @NonNull MenuInflater inflater)
+    public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater inflater)
     {
         inflater.inflate(R.menu.fragment_storage_file_list, menu);
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
     @Override
-    public boolean onOptionsItemSelected(@NonNull MenuItem item)
+    public boolean onMenuItemSelected(@NonNull MenuItem item)
     {
         int itemId = item.getItemId();
         if (itemId == R.id.menu_file_open) {
@@ -253,7 +253,7 @@ public final class StorageFileListFragment extends Fragment
             }
             return true;
         }
-        return super.onOptionsItemSelected(item);
+        return false;
     }
 
 

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/StorageFileListFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/StorageFileListFragment.java
@@ -26,6 +26,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.BounceInterpolator;
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -41,10 +42,10 @@ import com.jefftharris.passwdsafe.db.RecentFilesDao;
 import com.jefftharris.passwdsafe.file.PasswdFileUri;
 import com.jefftharris.passwdsafe.lib.ActContext;
 import com.jefftharris.passwdsafe.lib.ApiCompat;
-import com.jefftharris.passwdsafe.lib.DocumentsContractCompat;
 import com.jefftharris.passwdsafe.lib.ManagedRef;
 import com.jefftharris.passwdsafe.lib.PasswdSafeUtil;
 import com.jefftharris.passwdsafe.lib.view.GuiUtils;
+import com.jefftharris.passwdsafe.view.OpenPsafe3DocActResultContract;
 
 import java.util.List;
 
@@ -79,8 +80,6 @@ public final class StorageFileListFragment extends Fragment
 
     private static final String TAG = "StorageFileListFragment";
 
-    private static final int OPEN_RC = 1;
-
     private static final int LOADER_FILES = 0;
 
     private Listener itsListener;
@@ -93,6 +92,7 @@ public final class StorageFileListFragment extends Fragment
     private StorageFileListAdapter itsFilesAdapter;
     private int itsFileIcon;
     private Uri itsLastOpenUri;
+    private ActivityResultLauncher<Uri> itsOpenDocLauncher;
 
 
     @Override
@@ -115,6 +115,10 @@ public final class StorageFileListFragment extends Fragment
         itsRecentFilesDao =
                 PasswdSafeDb.get(requireContext()).accessRecentFiles();
         itsRecentFilesDaoRef = new ManagedRef<>(itsRecentFilesDao);
+
+        itsOpenDocLauncher = registerForActivityResult(
+                new OpenPsafe3DocActResultContract(),
+                this::onOpenPsafe3DocResult);
     }
 
     @NonNull
@@ -190,25 +194,6 @@ public final class StorageFileListFragment extends Fragment
         itsRecentFilesDao = null;
         itsRecentFilesDaoRef.clear();
         itsRecentFilesDaoRef = null;
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data)
-    {
-        switch (requestCode) {
-        case OPEN_RC: {
-            PasswdSafeUtil.dbginfo(TAG, "onActivityResult open %d: %s",
-                                   resultCode, data);
-            if ((resultCode == Activity.RESULT_OK) && (data != null)) {
-                openUri(data);
-            }
-            break;
-        }
-        default: {
-            super.onActivityResult(requestCode, resultCode, data);
-            break;
-        }
-        }
     }
 
     @Override
@@ -378,27 +363,17 @@ public final class StorageFileListFragment extends Fragment
     /** Start the intent to open a file */
     private void startOpenFile()
     {
-        Intent intent = new Intent(
-                DocumentsContractCompat.INTENT_ACTION_OPEN_DOCUMENT);
+        itsOpenDocLauncher.launch(itsLastOpenUri);
+    }
 
-        Uri initialUri = (itsLastOpenUri != null) ? itsLastOpenUri :
-                         ApiCompat.getPrimaryStorageRootUri(requireContext());
-        if (initialUri != null) {
-            intent.putExtra(DocumentsContractCompat.EXTRA_INITIAL_URI,
-                            initialUri);
+
+    /** Handle the result of opening a file */
+    private void onOpenPsafe3DocResult(@Nullable Intent result)
+    {
+        PasswdSafeUtil.dbginfo(TAG, "onOpenPsafe3DocResult: %s", result);
+        if (result != null) {
+            openUri(result);
         }
-
-        intent.putExtra(DocumentsContractCompat.EXTRA_PROMPT,
-                        getString(R.string.open_password_file));
-        intent.putExtra(DocumentsContractCompat.EXTRA_SHOW_ADVANCED, true);
-
-        // Filter to only show results that can be "opened", such as a
-        // file (as opposed to a list of contacts or timezones)
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-
-        intent.setType("application/*");
-
-        startActivityForResult(intent, OPEN_RC);
     }
 
 

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/SyncProviderFilesFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/SyncProviderFilesFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -24,6 +24,7 @@ import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.core.view.MenuProvider;
 import androidx.cursoradapter.widget.SimpleCursorAdapter;
 import androidx.fragment.app.ListFragment;
 import androidx.loader.app.LoaderManager;
@@ -34,6 +35,7 @@ import com.jefftharris.passwdsafe.lib.PasswdSafeContract;
 import com.jefftharris.passwdsafe.lib.PasswdSafeUtil;
 import com.jefftharris.passwdsafe.lib.ProviderType;
 import com.jefftharris.passwdsafe.lib.Utils;
+import com.jefftharris.passwdsafe.lib.view.GuiUtils;
 import com.jefftharris.passwdsafe.lib.view.PasswdCursorLoader;
 import com.jefftharris.passwdsafe.util.ProviderSyncTask;
 
@@ -41,6 +43,7 @@ import com.jefftharris.passwdsafe.util.ProviderSyncTask;
  * The SyncProviderFilesFragment shows the list of files for a provider
  */
 public class SyncProviderFilesFragment extends ListFragment
+        implements MenuProvider
 {
     /** Listener interface for the owning activity */
     public interface Listener
@@ -67,7 +70,9 @@ public class SyncProviderFilesFragment extends ListFragment
 
 
     /** Create a new instance of the fragment */
-    public static SyncProviderFilesFragment newInstance(Uri providerUri)
+    @NonNull
+    public static SyncProviderFilesFragment newInstance(
+            @NonNull Uri providerUri)
     {
         SyncProviderFilesFragment frag = new SyncProviderFilesFragment();
         Bundle args = new Bundle();
@@ -103,11 +108,11 @@ public class SyncProviderFilesFragment extends ListFragment
      * @see android.support.v4.app.ListFragment#onCreateView(android.view.LayoutInflater, android.view.ViewGroup, android.os.Bundle)
      */
     @Override
-    public View onCreateView(LayoutInflater inflater,
+    public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container,
                              Bundle savedInstanceState)
     {
-        setHasOptionsMenu(true);
+        GuiUtils.enableOptionsMenu(this);
         return inflater.inflate(R.layout.fragment_sync_provider_files,
                                 container, false);
     }
@@ -245,22 +250,15 @@ public class SyncProviderFilesFragment extends ListFragment
         itsSyncTask.cancel();
     }
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onCreateOptionsMenu(android.view.Menu, android.view.MenuInflater)
-     */
     @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater)
+    public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater inflater)
     {
         inflater.inflate(R.menu.fragment_sync_provider_files, menu);
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onOptionsItemSelected(android.view.MenuItem)
-     */
     @Override
-    public boolean onOptionsItemSelected(MenuItem item)
+    public boolean onMenuItemSelected(@NonNull MenuItem item)
     {
         int itemId = item.getItemId();
         if (itemId == R.id.menu_sync_files) {
@@ -270,13 +268,10 @@ public class SyncProviderFilesFragment extends ListFragment
             itsListener.createNewFile(itsFilesUri);
             return true;
         }
-        return super.onOptionsItemSelected(item);
+        return false;
     }
 
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.ListFragment#onListItemClick(android.widget.ListView, android.view.View, int, long)
-     */
     @Override
     public void onListItemClick(@NonNull ListView l,
                                 @NonNull View v,

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/SyncProviderFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/SyncProviderFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -23,6 +23,7 @@ import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.core.view.MenuProvider;
 import androidx.cursoradapter.widget.SimpleCursorAdapter;
 import androidx.fragment.app.ListFragment;
 import androidx.loader.app.LoaderManager;
@@ -40,7 +41,8 @@ import com.jefftharris.passwdsafe.util.ProviderSyncTask;
  * The SyncProviderFragment allows the user to choose a sync provider
  */
 public class SyncProviderFragment extends ListFragment
-        implements LoaderCallbacks<Cursor>
+        implements LoaderCallbacks<Cursor>,
+                   MenuProvider
 {
     /** Listener interface for the owning activity */
     public interface Listener
@@ -71,7 +73,7 @@ public class SyncProviderFragment extends ListFragment
                              Bundle savedInstanceState)
     {
         if (itsListener.activityHasMenu()) {
-            setHasOptionsMenu(true);
+            GuiUtils.enableOptionsMenu(this);
         }
         View rootView = inflater.inflate(R.layout.fragment_sync_provider,
                                          container, false);
@@ -145,21 +147,20 @@ public class SyncProviderFragment extends ListFragment
 
 
     @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater)
+    public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater inflater)
     {
         inflater.inflate(R.menu.fragment_sync_provider, menu);
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
 
     @Override
-    public boolean onOptionsItemSelected(MenuItem item)
+    public boolean onMenuItemSelected(@NonNull MenuItem item)
     {
         if (item.getItemId() == R.id.menu_sync) {
             itsSyncTask.start(null, requireContext());
             return true;
         }
-        return super.onOptionsItemSelected(item);
+        return false;
     }
 
 
@@ -209,7 +210,7 @@ public class SyncProviderFragment extends ListFragment
     /**
      * Check whether the sync provider is present
      */
-    public static boolean checkProvider(Context ctx)
+    public static boolean checkProvider(@NonNull Context ctx)
     {
         ContentResolver res = ctx.getContentResolver();
         String type = res.getType(PasswdSafeContract.Providers.CONTENT_URI);

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/util/Optional.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/util/Optional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2023 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2023-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -37,6 +37,15 @@ public final class Optional<T>
     public static <T> Optional<T> of(@NonNull T obj)
     {
         return new Optional<>(true, Objects.requireNonNull(obj));
+    }
+
+    /**
+     * Create a maybe-empty optional value
+     */
+    @NonNull
+    public static <T> Optional<T> ofNullable(@Nullable T obj)
+    {
+        return new Optional<>(obj != null, obj);
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/ChooseRecordActResultContract.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/ChooseRecordActResultContract.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (©) 2026 Jeff Harris <jefftharris@gmail.com>
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+package com.jefftharris.passwdsafe.view;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import androidx.activity.result.contract.ActivityResultContract;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.jefftharris.passwdsafe.LauncherRecordShortcuts;
+import com.jefftharris.passwdsafe.PasswdSafeApp;
+import com.jefftharris.passwdsafe.file.PasswdRecord;
+import com.jefftharris.passwdsafe.util.Optional;
+
+/**
+ * Activity contract to choose a record
+ */
+public class ChooseRecordActResultContract
+        extends ActivityResultContract<ChooseRecordActResultContract.Args,
+                                       Optional<String>>
+{
+    public record Args(@Nullable Uri fileUri,
+                       @NonNull PasswdRecord.Type recType)
+    {
+    }
+
+    @NonNull
+    @Override
+    public Intent createIntent(@NonNull Context ctx, @NonNull Args args)
+    {
+        Intent intent =
+                new Intent(PasswdSafeApp.CHOOSE_RECORD_INTENT, args.fileUri(),
+                           ctx, LauncherRecordShortcuts.class);
+
+        // Do not allow mixed alias and shortcut references to a
+        // record to work around a bug in Password Safe that does
+        // not allow both
+        switch (args.recType()) {
+        case NORMAL -> {
+        }
+        case ALIAS ->
+                intent.putExtra(LauncherRecordShortcuts.FILTER_NO_SHORTCUT,
+                                true);
+        case SHORTCUT ->
+                intent.putExtra(LauncherRecordShortcuts.FILTER_NO_ALIAS, true);
+        }
+
+        return intent;
+    }
+
+    @Nullable
+    @Override
+    public Optional<String> parseResult(int resultCode, @Nullable Intent intent)
+    {
+        if ((intent == null) || (resultCode != Activity.RESULT_OK)) {
+            return null;
+        }
+        return Optional.ofNullable(
+                intent.getStringExtra(PasswdSafeApp.RESULT_DATA_UUID));
+    }
+}

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/ConfirmPromptDialog.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/ConfirmPromptDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -37,7 +37,7 @@ public class ConfirmPromptDialog extends AppCompatDialogFragment
                DialogInterface.OnCancelListener,
                DialogInterface.OnClickListener
 {
-    public static final String REQUEST_KEY = "ConfirmPromptDialog";
+    private static final String REQUEST_KEY = "ConfirmPromptDialog";
 
     private static final String ARG_CONFIRM = "confirm";
     private static final String ARG_CONFIRM_ARGS = "confirmArgs";
@@ -52,58 +52,61 @@ public class ConfirmPromptDialog extends AppCompatDialogFragment
     private AlertDialog itsDialog;
 
     /**
-     * Create a new instance
+     * Client for showing and checking result of the dialog
      */
-    @NonNull
-    public static ConfirmPromptDialog newInstance(String title,
-                                                  String prompt,
-                                                  String confirm,
-                                                  Bundle confirmArgs)
+    public static class Client extends DialogClient
     {
-        return newInstance(title, prompt, confirm, confirmArgs, null, null);
-    }
+        /**
+         * Constructor for a fragment
+         */
+        public <T extends Fragment & FragmentResultListener>
+        Client(@NonNull T listener, @NonNull String id)
+        {
+            super(REQUEST_KEY, id, listener.getParentFragmentManager(),
+                  listener, listener);
+        }
 
-    /**
-     * Create a new instance with a neutral option
-     */
-    @NonNull
-    public static ConfirmPromptDialog newInstance(String title,
-                                                  String prompt,
-                                                  String confirm,
-                                                  Bundle confirmArgs,
-                                                  String neutral,
-                                                  Bundle neutralArgs)
-    {
-        ConfirmPromptDialog dialog = new ConfirmPromptDialog();
-        Bundle args = new Bundle();
-        args.putString(ARG_TITLE, title);
-        args.putString(ARG_PROMPT, prompt);
-        args.putString(ARG_CONFIRM, confirm);
-        args.putBundle(ARG_CONFIRM_ARGS, confirmArgs);
-        args.putString(ARG_NEUTRAL, neutral);
-        args.putBundle(ARG_NEUTRAL_ARGS, neutralArgs);
-        dialog.setArguments(args);
-        return dialog;
-    }
+        /**
+         * Constructor for a fragment activity
+         */
+        public <T extends FragmentActivity & FragmentResultListener>
+        Client(@NonNull T listener, @NonNull String id)
+        {
+            super(REQUEST_KEY, id, listener.getSupportFragmentManager(),
+                  listener, listener);
+        }
 
-    /**
-     * Set the fragment listener for results
-     */
-    public static <T extends Fragment & FragmentResultListener>
-    void setListener(@NonNull T listener)
-    {
-        var fragMgr = listener.getParentFragmentManager();
-        fragMgr.setFragmentResultListener(REQUEST_KEY, listener, listener);
-    }
+        /**
+         * Show the dialog
+         */
+        public void show(String title,
+                         String prompt,
+                         String confirm,
+                         Bundle confirmArgs)
+        {
+            show(title, prompt, confirm, confirmArgs, null, null);
+        }
 
-    /**
-     * Set the fragment activity listener for results
-     */
-    public static <T extends FragmentActivity & FragmentResultListener>
-    void setListener(@NonNull T listener)
-    {
-        var fragMgr = listener.getSupportFragmentManager();
-        fragMgr.setFragmentResultListener(REQUEST_KEY, listener, listener);
+        /**
+         * Show the dialog with a neutral option
+         */
+        public void show(String title,
+                         String prompt,
+                         String confirm,
+                         Bundle confirmArgs,
+                         String neutral,
+                         Bundle neutralArgs)
+        {
+            ConfirmPromptDialog dialog = new ConfirmPromptDialog();
+            Bundle args = new Bundle();
+            args.putString(ARG_TITLE, title);
+            args.putString(ARG_PROMPT, prompt);
+            args.putString(ARG_CONFIRM, confirm);
+            args.putBundle(ARG_CONFIRM_ARGS, confirmArgs);
+            args.putString(ARG_NEUTRAL, neutral);
+            args.putBundle(ARG_NEUTRAL_ARGS, neutralArgs);
+            doShow(dialog, args);
+        }
     }
 
     @Override
@@ -153,17 +156,15 @@ public class ConfirmPromptDialog extends AppCompatDialogFragment
     {
         switch (which) {
         case AlertDialog.BUTTON_POSITIVE: {
-            Bundle args = requireArguments();
-            setResult(args.getBundle(ARG_CONFIRM_ARGS));
+            setResult(ARG_CONFIRM_ARGS);
             break;
         }
         case AlertDialog.BUTTON_NEGATIVE: {
-            setResult(CANCEL_ARGS);
+            setResult(null);
             break;
         }
         case AlertDialog.BUTTON_NEUTRAL: {
-            Bundle args = requireArguments();
-            setResult(args.getBundle(ARG_NEUTRAL_ARGS));
+            setResult(ARG_NEUTRAL_ARGS);
             break;
         }
         }
@@ -180,14 +181,16 @@ public class ConfirmPromptDialog extends AppCompatDialogFragment
     public void onCancel(@NonNull DialogInterface dialog)
     {
         super.onCancel(dialog);
-        setResult(CANCEL_ARGS);
+        setResult(null);
     }
 
-    private void setResult(@Nullable Bundle result)
+    private void setResult(@Nullable String resultKey)
     {
-        var fragMgr = getParentFragmentManager();
-        fragMgr.setFragmentResult(REQUEST_KEY,
-                                  (result != null) ? result : CANCEL_ARGS);
+        var args = requireArguments();
+        var result = args.getBundle(resultKey);
+        Client.setResult(requireArguments(),
+                         (result != null) ? result : CANCEL_ARGS,
+                         getParentFragmentManager());
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/CreateFileShortcutActResultContract.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/CreateFileShortcutActResultContract.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (©) 2026 Jeff Harris <jefftharris@gmail.com>
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+package com.jefftharris.passwdsafe.view;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import androidx.activity.result.contract.ActivityResultContract;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.jefftharris.passwdsafe.LauncherFileShortcuts;
+import com.jefftharris.passwdsafe.util.Optional;
+
+/**
+ * Activity contract to create a file shortcut
+ */
+public class CreateFileShortcutActResultContract
+        extends ActivityResultContract<Void, Optional<Uri>>
+{
+    @NonNull
+    @Override
+    public Intent createIntent(@NonNull Context ctx, Void ignored)
+    {
+        Intent intent = new Intent(Intent.ACTION_CREATE_SHORTCUT, null, ctx,
+                                   LauncherFileShortcuts.class);
+        intent.putExtra(LauncherFileShortcuts.EXTRA_IS_DEFAULT_FILE, true);
+        return intent;
+    }
+
+    @Nullable
+    @Override
+    public Optional<Uri> parseResult(int resultCode, @Nullable Intent intent)
+    {
+        if ((intent == null) || (resultCode != Activity.RESULT_OK)) {
+            return null;
+        }
+        Intent val = intent.getParcelableExtra(Intent.EXTRA_SHORTCUT_INTENT);
+        return Optional.ofNullable((val != null) ? val.getData() : null);
+    }
+}

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/CreatePsafe3DocActResultContract.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/CreatePsafe3DocActResultContract.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (©) 2026 Jeff Harris <jefftharris@gmail.com>
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+package com.jefftharris.passwdsafe.view;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import androidx.activity.result.contract.ActivityResultContract;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.jefftharris.passwdsafe.lib.DocumentsContractCompat;
+import com.jefftharris.passwdsafe.lib.PasswdSafeUtil;
+
+/**
+ * Activity contract to create a new psafe3 file document
+ */
+public class CreatePsafe3DocActResultContract
+        extends ActivityResultContract<String,
+                                       CreatePsafe3DocActResultContract.Result>
+{
+    public record Result(
+            Uri uri,
+            String testDisplayName)
+    {
+    }
+
+    @NonNull
+    @Override
+    public Intent createIntent(@NonNull Context context, String fileName)
+    {
+        Intent createIntent = new Intent(
+                DocumentsContractCompat.INTENT_ACTION_CREATE_DOCUMENT);
+
+        // Filter to only show results that can be "opened", such as
+        // a file (as opposed to a list of contacts or timezones).
+        createIntent.addCategory(Intent.CATEGORY_OPENABLE);
+
+        // Create a file with the requested MIME type and name.
+        createIntent.setType(PasswdSafeUtil.MIME_TYPE_PSAFE3);
+        createIntent.putExtra(Intent.EXTRA_TITLE, fileName);
+        return createIntent;
+    }
+
+    @Nullable
+    @Override
+    public Result parseResult(int resultCode, @Nullable Intent intent)
+    {
+        if ((intent == null) || (resultCode != Activity.RESULT_OK)) {
+            return null;
+        }
+        return new Result(intent.getData(),
+                          intent.getStringExtra("__test_display_name"));
+    }
+}

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/DatePickerDialogFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/DatePickerDialogFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2015-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2015-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -24,7 +24,7 @@ import java.util.Calendar;
 public class DatePickerDialogFragment extends DialogFragment
         implements DatePickerDialog.OnDateSetListener
 {
-    public static final String REQUEST_KEY = "DatePickerDialogFragment";
+    private static final String REQUEST_KEY = "DatePickerDialogFragment";
 
     private static final String ARG_YEAR = "year";
 
@@ -33,26 +33,28 @@ public class DatePickerDialogFragment extends DialogFragment
     private static final String ARG_DAY_OF_MONTH = "dayOfMonth";
 
     /**
-     * Create a new instance
+     * Client for showing and checking result of the dialog
      */
-    @NonNull
-    public static DatePickerDialogFragment newInstance(int year,
-                                                       int monthOfYear,
-                                                       int dayOfMonth)
+    public static class Client extends DialogClient
     {
-        DatePickerDialogFragment frag = new DatePickerDialogFragment();
-        frag.setArguments(createBundle(year, monthOfYear, dayOfMonth));
-        return frag;
-    }
+        /**
+         * Constructor for a fragment
+         */
+        public <T extends Fragment & FragmentResultListener> Client(
+                @NonNull T listener, @NonNull String id)
+        {
+            super(REQUEST_KEY, id, listener.getParentFragmentManager(),
+                  listener, listener);
+        }
 
-    /**
-     * Set the fragment listener for results
-     */
-    public static <T extends Fragment & FragmentResultListener>
-    void setListener(@NonNull T listener)
-    {
-        var fragMgr = listener.getParentFragmentManager();
-        fragMgr.setFragmentResultListener(REQUEST_KEY, listener, listener);
+        /**
+         * Show the dialog
+         */
+        public void show(int year, int monthOfYear, int dayOfMonth)
+        {
+            doShow(new DatePickerDialogFragment(),
+                   createBundle(year, monthOfYear, dayOfMonth));
+        }
     }
 
     /**
@@ -86,9 +88,9 @@ public class DatePickerDialogFragment extends DialogFragment
     public void onDateSet(DatePicker view, int year, int monthOfYear,
                           int dayOfMonth)
     {
-        var fragMgr = getParentFragmentManager();
-        fragMgr.setFragmentResult(REQUEST_KEY,
-                                  createBundle(year, monthOfYear, dayOfMonth));
+        Client.setResult(requireArguments(),
+                         createBundle(year, monthOfYear, dayOfMonth),
+                         getParentFragmentManager());
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/DialogClient.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/DialogClient.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (©) 2026 Jeff Harris <jefftharris@gmail.com>
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+package com.jefftharris.passwdsafe.view;
+
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentResultListener;
+import androidx.lifecycle.LifecycleOwner;
+
+import java.util.Objects;
+
+/**
+ * Abstract client for showing and checking results of a dialog
+ */
+public abstract class DialogClient
+{
+    private static final String ARG_REQUEST_KEY = "requestKey";
+
+    private final String itsKey;
+    private final FragmentManager itsFragMgr;
+
+    /**
+     * Common constructor
+     */
+    protected DialogClient(@NonNull String requestKeyBase,
+                           @NonNull String id,
+                           @NonNull FragmentManager fragMgr,
+                           @NonNull LifecycleOwner lifecycleOwner,
+                           @NonNull FragmentResultListener listener)
+    {
+        itsKey = requestKeyBase + "-" + id;
+        itsFragMgr = fragMgr;
+        itsFragMgr.setFragmentResultListener(itsKey, lifecycleOwner,
+                                             listener);
+    }
+
+    /**
+     * Check whether the fragment result key matches the dialog
+     */
+    public boolean checkKey(@NonNull String requestKey)
+    {
+        return itsKey.equals(requestKey);
+    }
+
+    /**
+     * Show an instance of the dialog with arguments
+     */
+    protected void doShow(@NonNull DialogFragment dialog,
+                          @NonNull Bundle args)
+    {
+        args.putString(ARG_REQUEST_KEY, itsKey);
+        dialog.setArguments(args);
+        dialog.show(itsFragMgr, itsKey);
+    }
+
+    /**
+     * Set the result of the dialog
+     */
+    protected static void setResult(@NonNull Bundle dialogArgs,
+                                    @NonNull Bundle result,
+                                    @NonNull FragmentManager fragMgr)
+    {
+        var requestKey = dialogArgs.getString(ARG_REQUEST_KEY);
+        fragMgr.setFragmentResult(Objects.requireNonNull(requestKey), result);
+    }
+}

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/NewGroupDialog.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/NewGroupDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -28,35 +28,37 @@ import com.jefftharris.passwdsafe.lib.PasswdSafeUtil;
 import com.jefftharris.passwdsafe.lib.view.AbstractDialogClickListener;
 import com.jefftharris.passwdsafe.lib.view.GuiUtils;
 
-import org.jetbrains.annotations.Contract;
-
 /**
  * Dialog to select a new group
  */
 public class NewGroupDialog extends AppCompatDialogFragment
 {
-    public static final String REQUEST_KEY = "NewGroupDialog";
-
     public static final String ARG_GROUP = "group";
 
-    /**
-     * Create a new instance
-     */
-    @NonNull
-    @Contract(" -> new")
-    public static NewGroupDialog newInstance()
-    {
-        return new NewGroupDialog();
-    }
+    private static final String REQUEST_KEY = "NewGroupDialog";
 
     /**
-     * Set the fragment listener for results
+     * Client for showing and checking result of the dialog
      */
-    public static <T extends Fragment & FragmentResultListener>
-    void setListener(@NonNull T listener)
+    public static class Client extends DialogClient
     {
-        var fragMgr = listener.getParentFragmentManager();
-        fragMgr.setFragmentResultListener(REQUEST_KEY, listener, listener);
+        /**
+         * Constructor for a fragment
+         */
+        public <T extends Fragment & FragmentResultListener> Client(
+                @NonNull T listener, @NonNull String id)
+        {
+            super(REQUEST_KEY, id, listener.getParentFragmentManager(),
+                  listener, listener);
+        }
+
+        /**
+         * Show the dialog
+         */
+        public void show()
+        {
+            doShow(new NewGroupDialog(), new Bundle());
+        }
     }
 
     @Override
@@ -102,9 +104,9 @@ public class NewGroupDialog extends AppCompatDialogFragment
 
     private void setResult(@Nullable String group)
     {
-        var fragMgr = getParentFragmentManager();
         var result = new Bundle();
         result.putString(ARG_GROUP, group);
-        fragMgr.setFragmentResult(REQUEST_KEY, result);
+        Client.setResult(requireArguments(), result,
+                         getParentFragmentManager());
     }
 }

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/OpenPsafe3DocActResultContract.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/OpenPsafe3DocActResultContract.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (©) 2026 Jeff Harris <jefftharris@gmail.com>
+ * All rights reserved. Use of the code is allowed under the
+ * Artistic License 2.0 terms, as specified in the LICENSE file
+ * distributed with this code, or available from
+ * http://www.opensource.org/licenses/artistic-license-2.0.php
+ */
+package com.jefftharris.passwdsafe.view;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import androidx.activity.result.contract.ActivityResultContract;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.jefftharris.passwdsafe.R;
+import com.jefftharris.passwdsafe.lib.ApiCompat;
+import com.jefftharris.passwdsafe.lib.DocumentsContractCompat;
+
+/**
+ * Activity contract to open a psafe3 file document
+ */
+public class OpenPsafe3DocActResultContract
+        extends ActivityResultContract<Uri, Intent>
+{
+    @NonNull
+    @Override
+    public Intent createIntent(@NonNull Context ctx, @Nullable Uri lastOpenUri)
+    {
+        Intent intent = new Intent(
+                DocumentsContractCompat.INTENT_ACTION_OPEN_DOCUMENT);
+
+        Uri initialUri = (lastOpenUri != null) ? lastOpenUri :
+                         ApiCompat.getPrimaryStorageRootUri(ctx);
+        if (initialUri != null) {
+            intent.putExtra(DocumentsContractCompat.EXTRA_INITIAL_URI,
+                            initialUri);
+        }
+
+        intent.putExtra(DocumentsContractCompat.EXTRA_PROMPT,
+                        ctx.getString(R.string.open_password_file));
+        intent.putExtra(DocumentsContractCompat.EXTRA_SHOW_ADVANCED, true);
+
+        // Filter to only show results that can be "opened", such as a
+        // file (as opposed to a list of contacts or timezones)
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+
+        intent.setType("application/*");
+
+        return intent;
+    }
+
+    @Nullable
+    @Override
+    public Intent parseResult(int resultCode, @Nullable Intent intent)
+    {
+        if ((intent == null) || (resultCode != Activity.RESULT_OK)) {
+            return null;
+        }
+        return intent;
+    }
+}

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/PasswdPolicyEditDialog.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/PasswdPolicyEditDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2012-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2012-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -47,12 +47,11 @@ import java.util.ArrayList;
  */
 public class PasswdPolicyEditDialog extends AppCompatDialogFragment
 {
-    public static final String REQUEST_KEY = "PasswdPolicyEditDialog";
-
     public record ResultPolicies(PasswdPolicy oldPolicy, PasswdPolicy newPolicy)
     {
     }
 
+    private static final String REQUEST_KEY = "PasswdPolicyEditDialog";
     private static final String ARG_POLICY = "policy";
     private static final String ARG_EXISTING_POLICIES = "existingPolicies";
     private static final String ARG_NEW_POLICY = "newPolicy";
@@ -74,31 +73,34 @@ public class PasswdPolicyEditDialog extends AppCompatDialogFragment
     private String itsDefaultSymbols;
 
     /**
-     * Create a new instance
-     * @param policy The policy to edit; null for an add
-     * @param existingPolicies Existing policy names; null for none
+     * Client for showing and checking result of the dialog
      */
-    @NonNull
-    public static PasswdPolicyEditDialog newInstance(
-            @Nullable PasswdPolicy policy,
-            @Nullable ArrayList<String> existingPolicies)
+    public static class Client extends DialogClient
     {
-        PasswdPolicyEditDialog dlg = new PasswdPolicyEditDialog();
-        Bundle args = new Bundle();
-        args.putParcelable(ARG_POLICY, policy);
-        args.putStringArrayList(ARG_EXISTING_POLICIES, existingPolicies);
-        dlg.setArguments(args);
-        return dlg;
-    }
+        /**
+         * Constructor for a fragment
+         */
+        public <T extends Fragment & FragmentResultListener> Client(
+                @NonNull T listener, @NonNull String id)
+        {
+            super(REQUEST_KEY, id, listener.getParentFragmentManager(),
+                  listener, listener);
+        }
 
-    /**
-     * Set the fragment listener for results
-     */
-    public static <T extends Fragment & FragmentResultListener>
-    void setListener(@NonNull T listener)
-    {
-        var fragMgr = listener.getParentFragmentManager();
-        fragMgr.setFragmentResultListener(REQUEST_KEY, listener, listener);
+        /**
+         * Show the dialog
+         * @param policy The policy to edit; null for an add
+         * @param existingPolicies Existing policy names; null for none
+         */
+        public void show(
+                @Nullable PasswdPolicy policy,
+                @Nullable ArrayList<String> existingPolicies)
+        {
+            Bundle args = new Bundle();
+            args.putParcelable(ARG_POLICY, policy);
+            args.putStringArrayList(ARG_EXISTING_POLICIES, existingPolicies);
+            doShow(new PasswdPolicyEditDialog(), args);
+        }
     }
 
     @NonNull
@@ -258,9 +260,8 @@ public class PasswdPolicyEditDialog extends AppCompatDialogFragment
         Bundle result = new Bundle();
         result.putParcelable(ARG_POLICY, itsPolicy);
         result.putParcelable(ARG_NEW_POLICY, createPolicy());
-
-        var fragMgr = getParentFragmentManager();
-        fragMgr.setFragmentResult(REQUEST_KEY, result);
+        Client.setResult(requireArguments(), result,
+                         getParentFragmentManager());
     }
 
     /**

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/TimePickerDialogFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/view/TimePickerDialogFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2015-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2015-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -25,32 +25,35 @@ import java.util.Calendar;
 public class TimePickerDialogFragment extends DialogFragment
         implements TimePickerDialog.OnTimeSetListener
 {
-    public static final String REQUEST_KEY = "TimePickerDialogFragment";
+    private static final String REQUEST_KEY = "TimePickerDialogFragment";
 
     private static final String ARG_HOUR_OF_DAY = "hourOfDay";
 
     private static final String ARG_MINUTE = "minute";
 
     /**
-     * Create a new instance
+     * Client for showing and checking result of the dialog
      */
-    @NonNull
-    public static TimePickerDialogFragment newInstance(int hourOfDay,
-                                                       int minute)
+    public static class Client extends DialogClient
     {
-        TimePickerDialogFragment frag = new TimePickerDialogFragment();
-        frag.setArguments(createBundle(hourOfDay, minute));
-        return frag;
-    }
+        /**
+         * Constructor for a fragment
+         */
+        public <T extends Fragment & FragmentResultListener> Client(
+                @NonNull T listener, @NonNull String id)
+        {
+            super(REQUEST_KEY, id, listener.getParentFragmentManager(),
+                  listener, listener);
+        }
 
-    /**
-     * Set the fragment listener for results
-     */
-    public static <T extends Fragment & FragmentResultListener>
-    void setListener(@NonNull T listener)
-    {
-        var fragMgr = listener.getParentFragmentManager();
-        fragMgr.setFragmentResultListener(REQUEST_KEY, listener, listener);
+        /**
+         * Show the dialog
+         */
+        public void show(int hourOfDay, int minute)
+        {
+            doShow(new TimePickerDialogFragment(),
+                   createBundle(hourOfDay, minute));
+        }
     }
 
     /**
@@ -82,8 +85,8 @@ public class TimePickerDialogFragment extends DialogFragment
     @Override
     public void onTimeSet(TimePicker view, int hourOfDay, int minute)
     {
-        var fragMgr = getParentFragmentManager();
-        fragMgr.setFragmentResult(REQUEST_KEY, createBundle(hourOfDay, minute));
+        Client.setResult(requireArguments(), createBundle(hourOfDay, minute),
+                         getParentFragmentManager());
     }
 
     @NonNull

--- a/sync/build.gradle
+++ b/sync/build.gradle
@@ -61,13 +61,13 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':lib')
     implementation 'androidx.lifecycle:lifecycle-livedata:2.10.0'
-    implementation('androidx.work:work-runtime:2.11.0') {
+    implementation('androidx.work:work-runtime:2.11.2') {
         exclude group: 'com.google.guava', module: 'listenablefuture'
     }
 
-    implementation 'com.google.android.gms:play-services-auth:21.4.0'
+    implementation 'com.google.android.gms:play-services-auth:21.5.1'
     // Google Drive
-    implementation('com.google.api-client:google-api-client-android:2.8.1') {
+    implementation('com.google.api-client:google-api-client-android:2.9.0') {
         exclude group: 'org.apache.httpcomponents'
     }
     implementation('com.google.apis:google-api-services-drive:v3-rev20230815-2.0.0') {
@@ -81,10 +81,10 @@ dependencies {
         exclude group: 'com.google.guava'
     }
     // OneDrive
-    implementation ('com.microsoft.identity.client:msal:8.1.1') {
+    implementation ('com.microsoft.identity.client:msal:8.3.0') {
         exclude group: 'com.microsoft.device.display'
     }
-    implementation 'com.microsoft.graph:microsoft-graph:6.59.0'
+    implementation 'com.microsoft.graph:microsoft-graph:6.62.0'
 }
 
 secrets {

--- a/sync/src/main/java/com/jefftharris/passwdsafe/sync/SyncLogsFragment.java
+++ b/sync/src/main/java/com/jefftharris/passwdsafe/sync/SyncLogsFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2024 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -19,6 +19,7 @@ import android.view.ViewGroup;
 import android.widget.ListView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.core.view.MenuProvider;
 import androidx.cursoradapter.widget.SimpleCursorAdapter;
 import androidx.fragment.app.ListFragment;
 import androidx.loader.app.LoaderManager;
@@ -36,6 +37,7 @@ import java.util.Locale;
  * Fragment to show the sync logs
  */
 public class SyncLogsFragment extends ListFragment
+        implements MenuProvider
 {
     private static final int LOADER_LOGS = 0;
     private static final String STATE_SHOW_ALL = "showAll";
@@ -54,7 +56,7 @@ public class SyncLogsFragment extends ListFragment
                              ViewGroup container,
                              Bundle savedInstanceState)
     {
-        setHasOptionsMenu(true);
+        GuiUtils.enableOptionsMenu(this);
 
         itsIsShowAll = (savedInstanceState != null) &&
                        savedInstanceState.getBoolean(STATE_SHOW_ALL, false);
@@ -182,9 +184,6 @@ public class SyncLogsFragment extends ListFragment
     }
 
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onSaveInstanceState(android.os.Bundle)
-     */
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState)
     {
@@ -193,25 +192,18 @@ public class SyncLogsFragment extends ListFragment
     }
 
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onCreateOptionsMenu(android.view.Menu, android.view.MenuInflater)
-     */
     @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater)
+    public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater inflater)
     {
         inflater.inflate(R.menu.fragment_sync_logs, menu);
-        super.onCreateOptionsMenu(menu, inflater);
 
         MenuItem item = menu.findItem(R.id.menu_show_all);
         item.setChecked(itsIsShowAll);
     }
 
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onOptionsItemSelected(android.view.MenuItem)
-     */
     @Override
-    public boolean onOptionsItemSelected(MenuItem item)
+    public boolean onMenuItemSelected(@NonNull MenuItem item)
     {
         if (item.getItemId() == R.id.menu_show_all) {
             itsIsShowAll = !item.isChecked();
@@ -220,11 +212,14 @@ public class SyncLogsFragment extends ListFragment
                                                           itsLogsCbs);
             return true;
         }
-        return super.onOptionsItemSelected(item);
+        return false;
     }
 
     @Override
-    public void onListItemClick(ListView l, @NonNull View v, int pos, long id)
+    public void onListItemClick(@NonNull ListView l,
+                                @NonNull View v,
+                                int pos,
+                                long id)
     {
         if (l.isItemChecked(pos)) {
             if (pos == itsSelItemPos) {

--- a/sync/src/main/java/com/jefftharris/passwdsafe/sync/lib/SyncedFilesFragment.java
+++ b/sync/src/main/java/com/jefftharris/passwdsafe/sync/lib/SyncedFilesFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2017 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2017-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -24,10 +24,12 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.core.view.MenuProvider;
 import androidx.fragment.app.ListFragment;
 
 import com.jefftharris.passwdsafe.lib.PasswdSafeUtil;
 import com.jefftharris.passwdsafe.lib.Utils;
+import com.jefftharris.passwdsafe.lib.view.GuiUtils;
 import com.jefftharris.passwdsafe.sync.R;
 
 import java.util.Comparator;
@@ -37,6 +39,7 @@ import java.util.List;
  *  Fragment to show synced password files
  */
 public class SyncedFilesFragment extends ListFragment
+        implements MenuProvider
 {
     /** Listener interface for the owning activity */
     public interface Listener
@@ -73,6 +76,7 @@ public class SyncedFilesFragment extends ListFragment
     private int itsProgressBarRefCount = 0;
 
     /** Create a new instance of the fragment */
+    @NonNull
     public static SyncedFilesFragment newInstance(String pathName,
                                                   String pathId)
     {
@@ -93,9 +97,6 @@ public class SyncedFilesFragment extends ListFragment
     }
 
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onCreate(android.os.Bundle)
-     */
     @Override
     public void onCreate(Bundle savedInstanceState)
     {
@@ -106,15 +107,12 @@ public class SyncedFilesFragment extends ListFragment
     }
 
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.ListFragment#onCreateView(android.view.LayoutInflater, android.view.ViewGroup, android.os.Bundle)
-     */
     @Override
-    public View onCreateView(LayoutInflater inflater,
+    public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container,
                              Bundle savedInstanceState)
     {
-        setHasOptionsMenu(true);
+        GuiUtils.enableOptionsMenu(this);
         View rootView = inflater.inflate(R.layout.fragment_synced_files,
                                          container, false);
 
@@ -139,9 +137,6 @@ public class SyncedFilesFragment extends ListFragment
     }
 
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.Fragment#onResume()
-     */
     @Override
     public void onResume()
     {
@@ -149,11 +144,8 @@ public class SyncedFilesFragment extends ListFragment
         reload();
     }
 
-    /**
-     * Initialize the contents of the Activity's standard options menu
-     */
     @Override
-    public void onCreateOptionsMenu(@NonNull Menu menu, MenuInflater inflater)
+    public void onCreateMenu(@NonNull Menu menu, @NonNull MenuInflater inflater)
     {
         inflater.inflate(R.menu.fragment_synced_files, menu);
 
@@ -162,25 +154,18 @@ public class SyncedFilesFragment extends ListFragment
 
         MenuItem item = menu.findItem(R.id.menu_parent_dir);
         item.setVisible(parentEnabled);
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
-    /**
-     * This hook is called whenever an item in your options menu is selected
-     */
     @Override
-    public boolean onOptionsItemSelected(MenuItem item)
+    public boolean onMenuItemSelected(@NonNull MenuItem item)
     {
         if (item.getItemId() == R.id.menu_parent_dir) {
             itsListener.changeParentDir();
             return true;
         }
-        return super.onOptionsItemSelected(item);
+        return false;
     }
 
-    /* (non-Javadoc)
-     * @see android.support.v4.app.ListFragment#onListItemClick(android.widget.ListView, android.view.View, int, long)
-     */
     @Override
     public void onListItemClick(@NonNull ListView l,
                                 @NonNull View v,
@@ -327,7 +312,7 @@ public class SyncedFilesFragment extends ListFragment
             protected final CheckBox itsSelected;
 
             /** Constructor */
-            protected ViewHolder(View view)
+            protected ViewHolder(@NonNull View view)
             {
                 itsText = view.findViewById(R.id.text);
                 itsModDate = view.findViewById(R.id.mod_date);
@@ -343,7 +328,7 @@ public class SyncedFilesFragment extends ListFragment
             implements Comparator<ListItem>
     {
         @Override
-        public int compare(ListItem lhs, ListItem rhs)
+        public int compare(@NonNull ListItem lhs, @NonNull ListItem rhs)
         {
             ProviderRemoteFile lhsFile = lhs.itsFile;
             ProviderRemoteFile rhsFile = rhs.itsFile;


### PR DESCRIPTION
Use activity result contracts to start activities and receive their results

Replace deprecated calls to options menu to use of the MenuProvider interface

Update dialogs to provide a Client class based on DialogClient.  Update dialog users to use the Client class.
    
Addresses: GH-14