### PR TITLE
passwdsafe: Use local copy of commons-codec library

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-This collective work is Copyright (c) 2010-2024 Jeff Harris.
+This collective work is Copyright (c) 2010-2026 Jeff Harris.
 Individual portions may be copyright by individual contributors, and
 are included in this collective work with permission of the copyright 
 owners. All rights reserved. Use of the code is allowed under the

--- a/LICENSES
+++ b/LICENSES
@@ -1,6 +1,7 @@
 Licenses for PasswdSafe are available at:
 - lib/src/main/assets/license-PasswdSafe.txt
 - lib/src/main/assets/license-android.txt
+- lib/src/main/assets/license-apache.txt
 - lib/src/main/assets/license-AndroidAssetStudio.txt
 - lib/src/main/assets/license-MaterialIcons.txt
 - lib/src/main/assets/license-icons.txt

--- a/lib/src/main/assets/license-apache.txt
+++ b/lib/src/main/assets/license-apache.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/lib/src/main/java/com/jefftharris/commons/codec/BinaryDecoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/BinaryDecoder.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec;
+
+/**
+ * Defines common decoding methods for byte array decoders.
+ */
+public interface BinaryDecoder extends Decoder {
+
+    /**
+     * Decodes a byte array and returns the results as a byte array.
+     *
+     * @param source A byte array which has been encoded with the appropriate encoder.
+     * @return a byte array that contains decoded content.
+     * @throws DecoderException A decoder exception is thrown if a Decoder encounters a failure condition during the decode process.
+     */
+    byte[] decode(byte[] source) throws DecoderException;
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/BinaryDecoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/BinaryDecoder.java
@@ -13,9 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec;
+package com.jefftharris.commons.codec;
 
 /**
  * Defines common decoding methods for byte array decoders.

--- a/lib/src/main/java/com/jefftharris/commons/codec/BinaryEncoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/BinaryEncoder.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec;
+
+/**
+ * Defines common encoding methods for byte array encoders.
+ */
+public interface BinaryEncoder extends Encoder {
+
+    /**
+     * Encodes a byte array and return the encoded data as a byte array.
+     *
+     * @param source Data to be encoded.
+     * @return A byte array containing the encoded data.
+     * @throws EncoderException thrown if the Encoder encounters a failure condition during the encoding process.
+     */
+    byte[] encode(byte[] source) throws EncoderException;
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/BinaryEncoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/BinaryEncoder.java
@@ -13,9 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec;
+package com.jefftharris.commons.codec;
 
 /**
  * Defines common encoding methods for byte array encoders.

--- a/lib/src/main/java/com/jefftharris/commons/codec/BinaryEncoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/BinaryEncoder.java
@@ -22,6 +22,7 @@ package com.jefftharris.commons.codec;
 /**
  * Defines common encoding methods for byte array encoders.
  */
+@SuppressWarnings({"RedundantThrows", "unused"})
 public interface BinaryEncoder extends Encoder {
 
     /**

--- a/lib/src/main/java/com/jefftharris/commons/codec/CharEncoding.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/CharEncoding.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Character encoding names required of every implementation of the Java platform.
+ *
+ * From the Java documentation for {@link Charset}:
+ * <p>
+ * <cite>Every implementation of the Java platform is required to support the following character encodings. Consult the
+ * release documentation for your implementation to see if any other encodings are supported. Consult the release
+ * documentation for your implementation to see if any other encodings are supported.</cite>
+ * </p>
+ *
+ * <ul>
+ * <li>{@code US-ASCII}<p>
+ * Seven-bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the Unicode character set.</p></li>
+ * <li>{@code ISO-8859-1}<p>
+ * ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.</p></li>
+ * <li>{@code UTF-8}<p>
+ * Eight-bit Unicode Transformation Format.</p></li>
+ * <li>{@code UTF-16BE}<p>
+ * Sixteen-bit Unicode Transformation Format, big-endian byte order.</p></li>
+ * <li>{@code UTF-16LE}<p>
+ * Sixteen-bit Unicode Transformation Format, little-endian byte order.</p></li>
+ * <li>{@code UTF-16}<p>
+ * Sixteen-bit Unicode Transformation Format, byte order specified by a mandatory initial byte-order mark (either order
+ * accepted on input, big-endian used on output.)</p></li>
+ * </ul>
+ *
+ * This perhaps would best belong in the [lang] project. Even if a similar interface is defined in [lang], it is not
+ * foreseen that [codec] would be made to depend on [lang].
+ *
+ * <p>
+ * This class is immutable and thread-safe.
+ * </p>
+ *
+ * @see Charset
+ * @since 1.4
+ */
+public class CharEncoding {
+
+    /**
+     * CharEncodingISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1.
+     * <p>
+     * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
+     *
+     * @see Charset
+     */
+    public static final String ISO_8859_1 = StandardCharsets.ISO_8859_1.name();
+
+    /**
+     * Seven-bit ASCII, also known as ISO646-US, also known as the Basic Latin block of the Unicode character set.
+     * <p>
+     * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
+     *
+     * @see Charset
+     */
+    public static final String US_ASCII = StandardCharsets.US_ASCII.name();
+
+    /**
+     * Sixteen-bit Unicode Transformation Format, The byte order specified by a mandatory initial byte-order mark
+     * (either order accepted on input, big-endian used on output)
+     * <p>
+     * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
+     *
+     * @see Charset
+     */
+    public static final String UTF_16 = StandardCharsets.UTF_16.name();
+
+    /**
+     * Sixteen-bit Unicode Transformation Format, big-endian byte order.
+     * <p>
+     * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
+     *
+     * @see Charset
+     */
+    public static final String UTF_16BE = StandardCharsets.UTF_16BE.name();
+
+    /**
+     * Sixteen-bit Unicode Transformation Format, little-endian byte order.
+     * <p>
+     * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
+     *
+     * @see Charset
+     */
+    public static final String UTF_16LE = StandardCharsets.UTF_16LE.name();
+
+    /**
+     * Eight-bit Unicode Transformation Format.
+     * <p>
+     * Every implementation of the Java platform is required to support this character encoding.
+     * </p>
+     *
+     * @see Charset
+     */
+    public static final String UTF_8 = StandardCharsets.UTF_8.name();
+
+    /**
+     * TODO Make private in 2.0.
+     *
+     * @deprecated TODO Make private in 2.0.
+     */
+    @Deprecated
+    public CharEncoding() {
+        // empty
+    }
+
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/CharEncoding.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/CharEncoding.java
@@ -13,9 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec;
+package com.jefftharris.commons.codec;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;

--- a/lib/src/main/java/com/jefftharris/commons/codec/CharEncoding.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/CharEncoding.java
@@ -58,6 +58,7 @@ import java.nio.charset.StandardCharsets;
  * @see Charset
  * @since 1.4
  */
+@SuppressWarnings({"JavadocBlankLines", "unused", "SpellCheckingInspection"})
 public class CharEncoding {
 
     /**
@@ -122,9 +123,9 @@ public class CharEncoding {
     public static final String UTF_8 = StandardCharsets.UTF_8.name();
 
     /**
-     * TODO Make private in 2.0.
+     * TODOapache Make private in 2.0.
      *
-     * @deprecated TODO Make private in 2.0.
+     * @deprecated TODOapache Make private in 2.0.
      */
     @Deprecated
     public CharEncoding() {

--- a/lib/src/main/java/com/jefftharris/commons/codec/CodecPolicy.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/CodecPolicy.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec;
+
+/**
+ * Defines encoding and decoding policies.
+ *
+ * @since 1.15
+ */
+public enum CodecPolicy {
+
+    /**
+     * The <em>strict</em> policy. Data that causes a codec to fail should throw an exception.
+     */
+    STRICT,
+
+    /**
+     * The <em>lenient</em> policy. Data that causes a codec to fail should not throw an exception.
+     */
+    LENIENT
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/CodecPolicy.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/CodecPolicy.java
@@ -13,9 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec;
+package com.jefftharris.commons.codec;
 
 /**
  * Defines encoding and decoding policies.

--- a/lib/src/main/java/com/jefftharris/commons/codec/Decoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/Decoder.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec;
+
+/**
+ * Provides the highest level of abstraction for Decoders.
+ * <p>
+ * This is the sister interface of {@link Encoder}. All Decoders implement this common generic interface.
+ * Allows a user to pass a generic Object to any Decoder implementation in the codec package.
+ * </p>
+ * <p>
+ * One of the two interfaces at the center of the codec package.
+ * </p>
+ */
+public interface Decoder {
+
+    /**
+     * Decodes an "encoded" Object and returns a "decoded" Object. Note that the implementation of this interface will
+     * try to cast the Object parameter to the specific type expected by a particular Decoder implementation. If a
+     * {@link ClassCastException} occurs this decode method will throw a DecoderException.
+     *
+     * @param source
+     *            the object to decode.
+     * @return a 'decoded" object.
+     * @throws DecoderException
+     *             a decoder exception can be thrown for any number of reasons. Some good candidates are that the
+     *             parameter passed to this method is null, a param cannot be cast to the appropriate type for a
+     *             specific encoder.
+     */
+    Object decode(Object source) throws DecoderException;
+}
+

--- a/lib/src/main/java/com/jefftharris/commons/codec/Decoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/Decoder.java
@@ -29,6 +29,7 @@ package com.jefftharris.commons.codec;
  * One of the two interfaces at the center of the codec package.
  * </p>
  */
+@SuppressWarnings("unused")
 public interface Decoder {
 
     /**

--- a/lib/src/main/java/com/jefftharris/commons/codec/Decoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/Decoder.java
@@ -13,9 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec;
+package com.jefftharris.commons.codec;
 
 /**
  * Provides the highest level of abstraction for Decoders.

--- a/lib/src/main/java/com/jefftharris/commons/codec/DecoderException.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/DecoderException.java
@@ -13,9 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec;
+package com.jefftharris.commons.codec;
 
 /**
  * Thrown when there is a failure condition during the decoding process. This exception is thrown when a {@link Decoder}

--- a/lib/src/main/java/com/jefftharris/commons/codec/DecoderException.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/DecoderException.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec;
+
+/**
+ * Thrown when there is a failure condition during the decoding process. This exception is thrown when a {@link Decoder}
+ * encounters a decoding specific exception such as invalid data, or characters outside of the expected range.
+ */
+public class DecoderException extends Exception {
+
+    /**
+     * Declares the Serial Version Uid.
+     *
+     * @see <a href="https://c2.com/cgi/wiki?AlwaysDeclareSerialVersionUid">Always Declare Serial Version Uid</a>
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @since 1.4
+     */
+    public DecoderException() {
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently
+     * be initialized by a call to {@link #initCause}.
+     *
+     * @param message
+     *            The detail message which is saved for later retrieval by the {@link #getMessage()} method.
+     */
+    public DecoderException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to
+     * {@link #initCause}.
+     *
+     * @param message The format message which is saved for later retrieval by the {@link #getMessage()} method.
+     * @param args    the format arguments to use.
+     *
+     * @see String#format(String, Object...)
+     * @since 1.20.0
+     */
+    public DecoderException(final String message, final Object... args) {
+        super(String.format(message, args));
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     * <p>
+     * Note that the detail message associated with {@code cause} is not automatically incorporated into this
+     * exception's detail message.
+     * </p>
+     *
+     * @param message
+     *            The detail message which is saved for later retrieval by the {@link #getMessage()} method.
+     * @param cause
+     *            The cause which is saved for later retrieval by the {@link #getCause()} method. A {@code null}
+     *            value is permitted, and indicates that the cause is nonexistent or unknown.
+     * @since 1.4
+     */
+    public DecoderException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ?
+     * null : cause.toString())} (which typically contains the class and detail message of {@code cause}).
+     * This constructor is useful for exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            The cause which is saved for later retrieval by the {@link #getCause()} method. A {@code null}
+     *            value is permitted, and indicates that the cause is nonexistent or unknown.
+     * @since 1.4
+     */
+    public DecoderException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/DecoderException.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/DecoderException.java
@@ -23,6 +23,9 @@ package com.jefftharris.commons.codec;
  * Thrown when there is a failure condition during the decoding process. This exception is thrown when a {@link Decoder}
  * encounters a decoding specific exception such as invalid data, or characters outside of the expected range.
  */
+@SuppressWarnings(
+        {"MissingSerialAnnotation", "unused", "SpellCheckingInspection",
+         "GrazieStyle", "RedundantSuppression"})
 public class DecoderException extends Exception {
 
     /**

--- a/lib/src/main/java/com/jefftharris/commons/codec/Encoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/Encoder.java
@@ -27,6 +27,7 @@ package com.jefftharris.commons.codec;
  * in the codec package.
  * </p>
  */
+@SuppressWarnings("unused")
 public interface Encoder {
 
     /**

--- a/lib/src/main/java/com/jefftharris/commons/codec/Encoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/Encoder.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec;
+
+/**
+ * Provides the highest level of abstraction for Encoders.
+ * <p>
+ * This is the sister interface of {@link Decoder}.  Every implementation of Encoder provides this
+ * common generic interface which allows a user to pass a generic Object to any Encoder implementation
+ * in the codec package.
+ * </p>
+ */
+public interface Encoder {
+
+    /**
+     * Encodes an "Object" and returns the encoded content as an Object. The Objects here may just be
+     * {@code byte[]} or {@code String}s depending on the implementation used.
+     *
+     * @param source
+     *            An object to encode.
+     * @return An "encoded" Object.
+     * @throws EncoderException
+     *             An encoder exception is thrown if the encoder experiences a failure condition during the encoding
+     *             process.
+     */
+    Object encode(Object source) throws EncoderException;
+}
+

--- a/lib/src/main/java/com/jefftharris/commons/codec/Encoder.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/Encoder.java
@@ -13,9 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec;
+package com.jefftharris.commons.codec;
 
 /**
  * Provides the highest level of abstraction for Encoders.

--- a/lib/src/main/java/com/jefftharris/commons/codec/EncoderException.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/EncoderException.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec;
+
+/**
+ * Thrown when there is a failure condition during the encoding process. This exception is thrown when an
+ * {@link Encoder} encounters an encoding specific exception such as invalid data, inability to calculate a checksum,
+ * characters outside of the expected range.
+ */
+public class EncoderException extends Exception {
+
+    /**
+     * Declares the Serial Version Uid.
+     *
+     * @see <a href="https://c2.com/cgi/wiki?AlwaysDeclareSerialVersionUid">Always Declare Serial Version Uid</a>
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may
+     * subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @since 1.4
+     */
+    public EncoderException() {
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently
+     * be initialized by a call to {@link #initCause}.
+     *
+     * @param message
+     *            a useful message relating to the encoder specific error.
+     */
+    public EncoderException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * <p>
+     * Note that the detail message associated with {@code cause} is not automatically incorporated into this
+     * exception's detail message.
+     * </p>
+     *
+     * @param message
+     *            The detail message which is saved for later retrieval by the {@link #getMessage()} method.
+     * @param cause
+     *            The cause which is saved for later retrieval by the {@link #getCause()} method. A {@code null}
+     *            value is permitted, and indicates that the cause is nonexistent or unknown.
+     * @since 1.4
+     */
+    public EncoderException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail message of {@code (cause==null ?
+     * null : cause.toString())} (which typically contains the class and detail message of {@code cause}).
+     * This constructor is useful for exceptions that are little more than wrappers for other throwables.
+     *
+     * @param cause
+     *            The cause which is saved for later retrieval by the {@link #getCause()} method. A {@code null}
+     *            value is permitted, and indicates that the cause is nonexistent or unknown.
+     * @since 1.4
+     */
+    public EncoderException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/EncoderException.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/EncoderException.java
@@ -24,6 +24,9 @@ package com.jefftharris.commons.codec;
  * {@link Encoder} encounters an encoding specific exception such as invalid data, inability to calculate a checksum,
  * characters outside of the expected range.
  */
+@SuppressWarnings(
+        {"MissingSerialAnnotation", "unused", "SpellCheckingInspection",
+         "GrazieStyle", "RedundantSuppression"})
 public class EncoderException extends Exception {
 
     /**

--- a/lib/src/main/java/com/jefftharris/commons/codec/EncoderException.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/EncoderException.java
@@ -13,9 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec;
+package com.jefftharris.commons.codec;
 
 /**
  * Thrown when there is a failure condition during the encoding process. This exception is thrown when an

--- a/lib/src/main/java/com/jefftharris/commons/codec/NOTICE.txt
+++ b/lib/src/main/java/com/jefftharris/commons/codec/NOTICE.txt
@@ -1,0 +1,5 @@
+Apache Commons Codec
+Copyright 2002-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/Base32.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/Base32.java
@@ -13,13 +13,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec.binary;
+package com.jefftharris.commons.codec.binary;
 
 import java.util.Arrays;
 
-import org.apache.commons.codec.CodecPolicy;
+import com.jefftharris.commons.codec.CodecPolicy;
 
 /**
  * Provides Base32 encoding and decoding as defined by <a href="https://www.ietf.org/rfc/rfc4648.txt">RFC 4648</a>.
@@ -510,8 +512,8 @@ public class Base32 extends BaseNCodec {
      * for other bytes, too. This method subscribes to the garbage-in, garbage-out philosophy: it will not check the provided data for validity.
      * </p>
      * <p>
-     * Output is written to {@link org.apache.commons.codec.binary.BaseNCodec.Context#buffer Context#buffer} as 8-bit octets, using
-     * {@link org.apache.commons.codec.binary.BaseNCodec.Context#pos Context#pos} as the buffer position
+     * Output is written to {@link com.jefftharris.commons.codec.binary.BaseNCodec.Context#buffer Context#buffer} as 8-bit octets, using
+     * {@link com.jefftharris.commons.codec.binary.BaseNCodec.Context#pos Context#pos} as the buffer position
      * </p>
      *
      * @param input   byte[] array of ASCII data to Base32 decode.

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/Base32.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/Base32.java
@@ -58,6 +58,9 @@ import com.jefftharris.commons.codec.CodecPolicy;
  * @see <a href="https://www.ietf.org/rfc/rfc4648.txt">RFC 4648</a>
  * @since 1.5
  */
+@SuppressWarnings(
+        {"JavadocReference", "unused", "DeprecatedIsStillUsed", "deprecation",
+         "SpellCheckingInspection", "GrazieInspection", "RedundantSuppression"})
 public class Base32 extends BaseNCodec {
 
     /**
@@ -79,6 +82,7 @@ public class Base32 extends BaseNCodec {
      *
      * @since 1.17.0
      */
+    @SuppressWarnings({"unused", "WeakerAccess"})
     public static class Builder extends AbstractBuilder<Base32, Builder> {
 
         /**

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/Base32.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/Base32.java
@@ -1,0 +1,774 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec.binary;
+
+import java.util.Arrays;
+
+import org.apache.commons.codec.CodecPolicy;
+
+/**
+ * Provides Base32 encoding and decoding as defined by <a href="https://www.ietf.org/rfc/rfc4648.txt">RFC 4648</a>.
+ *
+ * <p>
+ * The class can be parameterized in the following manner with various constructors:
+ * </p>
+ * <ul>
+ * <li>Whether to use the "base32hex" variant instead of the default "base32"</li>
+ * <li>Line length: Default 76. Line length that aren't multiples of 8 will still essentially end up being multiples of 8 in the encoded data.
+ * <li>Line separator: Default is CRLF ("\r\n")</li>
+ * </ul>
+ * <p>
+ * This class operates directly on byte streams, and not character streams.
+ * </p>
+ * <p>
+ * This class is thread-safe.
+ * </p>
+ * <p>
+ * To configure a new instance, use a {@link Builder}. For example:
+ * </p>
+ * <pre>
+ * Base32 base32 = Base32.builder()
+ *   .setDecodingPolicy(DecodingPolicy.LENIENT) // default is lenient
+ *   .setLineLength(0)                          // default is none
+ *   .setLineSeparator('\r', '\n')              // default is CR LF
+ *   .setPadding('=')                           // default is '='
+ *   .setEncodeTable(customEncodeTable)         // default is RFC 4648 Section 6, Table 3: The Base 32 Alphabet
+ *   .get()
+ * </pre>
+ *
+ * @see Base32InputStream
+ * @see Base32OutputStream
+ * @see <a href="https://www.ietf.org/rfc/rfc4648.txt">RFC 4648</a>
+ * @since 1.5
+ */
+public class Base32 extends BaseNCodec {
+
+    /**
+     * Builds {@link Base32} instances.
+     *
+     * <p>
+     * To configure a new instance, use a {@link Builder}. For example:
+     * </p>
+     *
+     * <pre>
+     * Base32 base32 = Base32.builder()
+     *   .setDecodingPolicy(DecodingPolicy.LENIENT) // default is lenient
+     *   .setLineLength(0)                          // default is none
+     *   .setLineSeparator('\r', '\n')              // default is CR LF
+     *   .setPadding('=')                           // default is '='
+     *   .setEncodeTable(customEncodeTable)         // default is RFC 4648 Section 6, Table 3: The Base 32 Alphabet
+     *   .get()
+     * </pre>
+     *
+     * @since 1.17.0
+     */
+    public static class Builder extends AbstractBuilder<Base32, Builder> {
+
+        /**
+         * Constructs a new instance using <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32
+         * Alphabet</a>.
+         */
+        public Builder() {
+            super(ENCODE_TABLE);
+            setDecodeTableRaw(DECODE_TABLE);
+            setEncodeTableRaw(ENCODE_TABLE);
+            setEncodedBlockSize(BYTES_PER_ENCODED_BLOCK);
+            setUnencodedBlockSize(BYTES_PER_UNENCODED_BLOCK);
+        }
+
+        @Override
+        public Base32 get() {
+            return new Base32(this);
+        }
+
+        @Override
+        public Builder setEncodeTable(final byte... encodeTable) {
+            super.setDecodeTableRaw(Arrays.equals(encodeTable, HEX_ENCODE_TABLE) ? HEX_DECODE_TABLE : DECODE_TABLE);
+            return super.setEncodeTable(encodeTable);
+        }
+
+        /**
+         * Sets the decode table to use Base32 hexadecimal if {@code true}, otherwise use the Base32 alphabet.
+         * <p>
+         * This overrides a value previously set with {@link #setEncodeTable(byte...)}.
+         * </p>
+         *
+         * @param useHex use Base32 hexadecimal if {@code true}, otherwise use the Base32 alphabet.
+         * @return {@code this} instance.
+         * @since 1.18.0
+         */
+        public Builder setHexDecodeTable(final boolean useHex) {
+            return setEncodeTable(decodeTable(useHex));
+        }
+
+        /**
+         * Sets the encode table to use Base32 hexadecimal if {@code true}, otherwise use the Base32 alphabet.
+         * <p>
+         * This overrides a value previously set with {@link #setEncodeTable(byte...)}.
+         * </p>
+         *
+         * @param useHex
+         *               <ul>
+         *               <li>If true, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC 4648 Section 7, Table 4: Base 32 Encoding
+         *               with Extended Hex Alphabet</a></li>
+         *               <li>If false, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32
+         *               Alphabet</a></li>
+         *               </ul>
+         * @return {@code this} instance.
+         * @since 1.18.0
+         */
+        public Builder setHexEncodeTable(final boolean useHex) {
+            return setEncodeTable(encodeTable(useHex));
+        }
+    }
+
+    /**
+     * BASE32 characters are 5 bits in length. They are formed by taking a block of five octets to form a 40-bit string, which is converted into eight BASE32
+     * characters.
+     */
+    private static final int BITS_PER_ENCODED_BYTE = 5;
+
+    private static final int BYTES_PER_ENCODED_BLOCK = 8;
+    private static final int BYTES_PER_UNENCODED_BLOCK = 5;
+
+    /**
+     * This array is a lookup table that translates Unicode characters drawn from the "Base32 Alphabet" (as specified in Table 3 of RFC 4648) into their 5-bit
+     * positive integer equivalents. Characters that are not in the Base32 alphabet but fall within the bounds of the array are translated to -1.
+     */
+    // @formatter:off
+    private static final byte[] DECODE_TABLE = {
+         //  0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 00-0f
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10-1f
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 20-2f
+            -1, -1, 26, 27, 28, 29, 30, 31, -1, -1, -1, -1, -1, -1, -1, -1, // 30-3f 2-7
+            -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, // 40-4f A-O
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,                     // 50-5a P-Z
+                                                        -1, -1, -1, -1, -1, // 5b-5f
+            -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, // 60-6f a-o
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,                     // 70-7a p-z
+    };
+    // @formatter:on
+
+    /**
+     * This array is a lookup table that translates 5-bit positive integer index values into their "Base32 Alphabet" equivalents as specified in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32 Alphabet</a>.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32 Alphabet</a>
+     */
+    // @formatter:off
+    private static final byte[] ENCODE_TABLE = {
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            '2', '3', '4', '5', '6', '7',
+    };
+    // @formatter:on
+
+    /**
+     * This array is a lookup table that translates Unicode characters drawn from the "Base32 Hex Alphabet" (as specified in Table 4 of RFC 4648) into their
+     * 5-bit positive integer equivalents. Characters that are not in the Base32 Hex alphabet but fall within the bounds of the array are translated to -1.
+     */
+    // @formatter:off
+    private static final byte[] HEX_DECODE_TABLE = {
+         //  0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 00-0f
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10-1f
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 20-2f
+             0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, -1, -1, // 30-3f 0-9
+            -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 40-4f A-O
+            25, 26, 27, 28, 29, 30, 31,                                     // 50-56 P-V
+                                        -1, -1, -1, -1, -1, -1, -1, -1, -1, // 57-5f
+            -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, // 60-6f a-o
+            25, 26, 27, 28, 29, 30, 31                                      // 70-76 p-v
+    };
+    // @formatter:on
+
+    /**
+     * This array is a lookup table that translates 5-bit positive integer index values into their "Base 32 Encoding with Extended Hex Alphabet" equivalents as
+     * specified in <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC 4648 Section 7, Table 4: Base 32 Encoding with Extended Hex
+     * Alphabet</a>.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC 4648 Section 7, Table 4: Base 32 Encoding with Extended Hex Alphabet</a>
+     */
+    // @formatter:off
+    private static final byte[] HEX_ENCODE_TABLE = {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+    };
+    // @formatter:on
+
+    /** Mask used to extract 5 bits, used when encoding Base32 bytes */
+    private static final int MASK_5_BITS = 0x1f;
+
+    /** Mask used to extract 4 bits, used when decoding final trailing character. */
+    private static final long MASK_4_BITS = 0x0fL;
+
+    /** Mask used to extract 3 bits, used when decoding final trailing character. */
+    private static final long MASK_3_BITS = 0x07L;
+
+    /** Mask used to extract 2 bits, used when decoding final trailing character. */
+    private static final long MASK_2_BITS = 0x03L;
+
+    /** Mask used to extract 1 bits, used when decoding final trailing character. */
+    private static final long MASK_1_BITS = 0x01L;
+
+    // The static final fields above are used for the original static byte[] methods on Base32.
+    // The private member fields below are used with the new streaming approach, which requires
+    // some state be preserved between calls of encode() and decode().
+
+    /**
+     * Creates a new Builder.
+     *
+     * <p>
+     * To configure a new instance, use a {@link Builder}. For example:
+     * </p>
+     *
+     * <pre>
+     * Base32 base32 = Base32.builder()
+     *   .setDecodingPolicy(DecodingPolicy.LENIENT) // default is lenient
+     *   .setLineLength(0)                          // default is none
+     *   .setLineSeparator('\r', '\n')              // default is CR LF
+     *   .setPadding('=')                           // default is '='
+     *   .setEncodeTable(customEncodeTable)         // default is RFC 4648 Section 6, Table 3: The Base 32 Alphabet
+     *   .get()
+     * </pre>
+     *
+     * @return a new Builder.
+     * @since 1.17.0
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static byte[] decodeTable(final boolean useHex) {
+        return useHex ? HEX_DECODE_TABLE : DECODE_TABLE;
+    }
+
+    /**
+     * Gets the encoding table that matches {@code useHex}.
+     *
+     * @param useHex
+     *               <ul>
+     *               <li>If true, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC 4648 Section 7, Table 4: Base 32 Encoding with
+     *               Extended Hex Alphabet</a></li>
+     *               <li>If false, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32
+     *               Alphabet</a></li>
+     *               </ul>
+     * @return the encoding table that matches {@code useHex}.
+     */
+    private static byte[] encodeTable(final boolean useHex) {
+        return useHex ? HEX_ENCODE_TABLE : ENCODE_TABLE;
+    }
+
+    /**
+     * Convenience variable to help us determine when our buffer is going to run out of room and needs resizing. {@code encodeSize = {@link
+     * #BYTES_PER_ENCODED_BLOCK} + lineSeparator.length;}
+     */
+    private final int encodeSize;
+
+    /**
+     * Line separator for encoding. Not used when decoding. Only used if lineLength &gt; 0.
+     */
+    private final byte[] lineSeparator;
+
+    /**
+     * Constructs a Base32 codec used for decoding and encoding.
+     * <p>
+     * When encoding the line length is 0 (no chunking).
+     * </p>
+     */
+    public Base32() {
+        this(false);
+    }
+
+    /**
+     * Constructs a Base32 codec used for decoding and encoding.
+     * <p>
+     * When encoding the line length is 0 (no chunking).
+     * </p>
+     *
+     * @param useHex
+     *               <ul>
+     *               <li>If true, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC 4648 Section 7, Table 4: Base 32 Encoding with
+     *               Extended Hex Alphabet</a></li>
+     *               <li>If false, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32
+     *               Alphabet</a></li>
+     *               </ul>
+     * @deprecated Use {@link #builder()} and {@link Builder}.
+     */
+    @Deprecated
+    public Base32(final boolean useHex) {
+        this(0, null, useHex, PAD_DEFAULT);
+    }
+
+    /**
+     * Constructs a Base32 codec used for decoding and encoding.
+     * <p>
+     * When encoding the line length is 0 (no chunking).
+     * </p>
+     *
+     * @param useHex
+     *               <ul>
+     *               <li>If true, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC 4648 Section 7, Table 4: Base 32 Encoding with
+     *               Extended Hex Alphabet</a></li>
+     *               <li>If false, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32
+     *               Alphabet</a></li>
+     *               </ul>
+     * @param padding byte used as padding byte.
+     * @deprecated Use {@link #builder()} and {@link Builder}.
+     */
+    @Deprecated
+    public Base32(final boolean useHex, final byte padding) {
+        this(0, null, useHex, padding);
+    }
+
+    private Base32(final Builder builder) {
+        super(builder);
+        if (builder.getLineLength() > 0) {
+            final byte[] lineSeparator = builder.getLineSeparator();
+            // Must be done after initializing the tables
+            if (containsAlphabetOrPad(lineSeparator)) {
+                final String sep = StringUtils.newStringUtf8(lineSeparator);
+                throw new IllegalArgumentException("lineSeparator must not contain Base32 characters: [" + sep + "]");
+            }
+            this.encodeSize = BYTES_PER_ENCODED_BLOCK + lineSeparator.length;
+            this.lineSeparator = lineSeparator;
+        } else {
+            this.encodeSize = BYTES_PER_ENCODED_BLOCK;
+            this.lineSeparator = null;
+        }
+        if (isInAlphabet(builder.getPadding()) || Character.isWhitespace(builder.getPadding())) {
+            throw new IllegalArgumentException("pad must not be in alphabet or whitespace");
+        }
+    }
+
+    /**
+     * Constructs a Base32 codec used for decoding and encoding.
+     * <p>
+     * When encoding the line length is 0 (no chunking).
+     * </p>
+     *
+     * @param pad byte used as padding byte.
+     * @deprecated Use {@link #builder()} and {@link Builder}.
+     */
+    @Deprecated
+    public Base32(final byte pad) {
+        this(false, pad);
+    }
+
+    /**
+     * Constructs a Base32 codec used for decoding and encoding.
+     * <p>
+     * When encoding the line length is given in the constructor, the line separator is CRLF.
+     * </p>
+     *
+     * @param lineLength Each line of encoded data will be at most of the given length (rounded down to the nearest multiple of 8). If lineLength &lt;= 0, then
+     *                   the output will not be divided into lines (chunks). Ignored when decoding.
+     * @deprecated Use {@link #builder()} and {@link Builder}.
+     */
+    @Deprecated
+    public Base32(final int lineLength) {
+        this(lineLength, CHUNK_SEPARATOR);
+    }
+
+    /**
+     * Constructs a Base32 codec used for decoding and encoding.
+     * <p>
+     * When encoding the line length and line separator are given in the constructor.
+     * </p>
+     * <p>
+     * Line lengths that aren't multiples of 8 will still essentially end up being multiples of 8 in the encoded data.
+     * </p>
+     *
+     * @param lineLength    Each line of encoded data will be at most of the given length (rounded down to the nearest multiple of 8). If lineLength &lt;= 0,
+     *                      then the output will not be divided into lines (chunks). Ignored when decoding.
+     * @param lineSeparator Each line of encoded data will end with this sequence of bytes.
+     * @throws IllegalArgumentException Thrown when the {@code lineSeparator} contains Base32 characters.
+     * @deprecated Use {@link #builder()} and {@link Builder}.
+     */
+    @Deprecated
+    public Base32(final int lineLength, final byte[] lineSeparator) {
+        this(lineLength, lineSeparator, false, PAD_DEFAULT);
+    }
+
+    /**
+     * Constructs a Base32 / Base32 Hex codec used for decoding and encoding.
+     * <p>
+     * When encoding the line length and line separator are given in the constructor.
+     * </p>
+     * <p>
+     * Line lengths that aren't multiples of 8 will still essentially end up being multiples of 8 in the encoded data.
+     * </p>
+     *
+     * @param lineLength    Each line of encoded data will be at most of the given length (rounded down to the nearest multiple of 8). If lineLength &lt;= 0,
+     *                      then the output will not be divided into lines (chunks). Ignored when decoding.
+     * @param lineSeparator Each line of encoded data will end with this sequence of bytes.
+     * @param useHex
+     *               <ul>
+     *               <li>If true, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC 4648 Section 7, Table 4: Base 32 Encoding with
+     *               Extended Hex Alphabet</a></li>
+     *               <li>If false, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32
+     *               Alphabet</a></li>
+     *               </ul>
+     * @throws IllegalArgumentException Thrown when the {@code lineSeparator} contains Base32 characters. Or the lineLength &gt; 0 and lineSeparator is null.
+     * @deprecated Use {@link #builder()} and {@link Builder}.
+     */
+    @Deprecated
+    public Base32(final int lineLength, final byte[] lineSeparator, final boolean useHex) {
+        this(lineLength, lineSeparator, useHex, PAD_DEFAULT);
+    }
+
+    /**
+     * Constructs a Base32 / Base32 Hex codec used for decoding and encoding.
+     * <p>
+     * When encoding the line length and line separator are given in the constructor.
+     * </p>
+     * <p>
+     * Line lengths that aren't multiples of 8 will still essentially end up being multiples of 8 in the encoded data.
+     * </p>
+     *
+     * @param lineLength    Each line of encoded data will be at most of the given length (rounded down to the nearest multiple of 8). If lineLength &lt;= 0,
+     *                      then the output will not be divided into lines (chunks). Ignored when decoding.
+     * @param lineSeparator Each line of encoded data will end with this sequence of bytes.
+     * @param useHex
+     *               <ul>
+     *               <li>If true, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC 4648 Section 7, Table 4: Base 32 Encoding with
+     *               Extended Hex Alphabet</a></li>
+     *               <li>If false, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32
+     *               Alphabet</a></li>
+     *               </ul>
+     * @param padding       padding byte.
+     * @throws IllegalArgumentException Thrown when the {@code lineSeparator} contains Base32 characters. Or the lineLength &gt; 0 and lineSeparator is null.
+     * @deprecated Use {@link #builder()} and {@link Builder}.
+     */
+    @Deprecated
+    public Base32(final int lineLength, final byte[] lineSeparator, final boolean useHex, final byte padding) {
+        this(lineLength, lineSeparator, useHex, padding, DECODING_POLICY_DEFAULT);
+    }
+
+    /**
+     * Constructs a Base32 / Base32 Hex codec used for decoding and encoding.
+     * <p>
+     * When encoding the line length and line separator are given in the constructor.
+     * </p>
+     * <p>
+     * Line lengths that aren't multiples of 8 will still essentially end up being multiples of 8 in the encoded data.
+     * </p>
+     *
+     * @param lineLength     Each line of encoded data will be at most of the given length (rounded down to the nearest multiple of 8). If lineLength &lt;= 0,
+     *                       then the output will not be divided into lines (chunks). Ignored when decoding.
+     * @param lineSeparator  Each line of encoded data will end with this sequence of bytes.
+     * @param useHex
+     *               <ul>
+     *               <li>If true, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-7">RFC 4648 Section 7, Table 4: Base 32 Encoding with
+     *               Extended Hex Alphabet</a></li>
+     *               <li>If false, then use <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">RFC 4648 Section 6, Table 3: The Base 32
+     *               Alphabet</a></li>
+     *               </ul>
+     * @param padding        padding byte.
+     * @param decodingPolicy The decoding policy.
+     * @throws IllegalArgumentException Thrown when the {@code lineSeparator} contains Base32 characters. Or the lineLength &gt; 0 and lineSeparator is null.
+     * @since 1.15
+     * @deprecated Use {@link #builder()} and {@link Builder}.
+     */
+    @Deprecated
+    public Base32(final int lineLength, final byte[] lineSeparator, final boolean useHex, final byte padding, final CodecPolicy decodingPolicy) {
+        // @formatter:off
+        this(builder()
+                .setLineLength(lineLength)
+                .setLineSeparator(lineSeparator != null ? lineSeparator : EMPTY_BYTE_ARRAY)
+                .setDecodeTable(decodeTable(useHex))
+                .setEncodeTableRaw(encodeTable(useHex))
+                .setPadding(padding)
+                .setDecodingPolicy(decodingPolicy));
+        // @formatter:on
+    }
+
+    /**
+     * <p>
+     * Decodes all of the provided data, starting at inPos, for inAvail bytes. Should be called at least twice: once with the data to decode, and once with
+     * inAvail set to "-1" to alert decoder that EOF has been reached. The "-1" call is not necessary when decoding, but it doesn't hurt, either.
+     * </p>
+     * <p>
+     * Ignores all non-Base32 characters. This is how chunked (for example 76 character) data is handled, since CR and LF are silently ignored, but has implications
+     * for other bytes, too. This method subscribes to the garbage-in, garbage-out philosophy: it will not check the provided data for validity.
+     * </p>
+     * <p>
+     * Output is written to {@link org.apache.commons.codec.binary.BaseNCodec.Context#buffer Context#buffer} as 8-bit octets, using
+     * {@link org.apache.commons.codec.binary.BaseNCodec.Context#pos Context#pos} as the buffer position
+     * </p>
+     *
+     * @param input   byte[] array of ASCII data to Base32 decode.
+     * @param inPos   Position to start reading data from.
+     * @param inAvail Amount of bytes available from input for decoding.
+     * @param context the context to be used.
+     */
+    @Override
+    void decode(final byte[] input, int inPos, final int inAvail, final Context context) {
+        // package protected for access from I/O streams
+        if (context.eof) {
+            return;
+        }
+        if (inAvail < 0) {
+            context.eof = true;
+        }
+        final int decodeSize = this.encodeSize - 1;
+        for (int i = 0; i < inAvail; i++) {
+            final byte b = input[inPos++];
+            if (b == pad) {
+                // We're done.
+                context.eof = true;
+                break;
+            }
+            final byte[] buffer = ensureBufferSize(decodeSize, context);
+            if (b >= 0 && b < this.decodeTable.length) {
+                final int result = this.decodeTable[b];
+                if (result >= 0) {
+                    context.modulus = (context.modulus + 1) % BYTES_PER_ENCODED_BLOCK;
+                    // collect decoded bytes
+                    context.lbitWorkArea = (context.lbitWorkArea << BITS_PER_ENCODED_BYTE) + result;
+                    if (context.modulus == 0) { // we can output the 5 bytes
+                        buffer[context.pos++] = (byte) (context.lbitWorkArea >> 32 & MASK_8BITS);
+                        buffer[context.pos++] = (byte) (context.lbitWorkArea >> 24 & MASK_8BITS);
+                        buffer[context.pos++] = (byte) (context.lbitWorkArea >> 16 & MASK_8BITS);
+                        buffer[context.pos++] = (byte) (context.lbitWorkArea >> 8 & MASK_8BITS);
+                        buffer[context.pos++] = (byte) (context.lbitWorkArea & MASK_8BITS);
+                    }
+                }
+            }
+        }
+        // Two forms of EOF as far as Base32 decoder is concerned: actual
+        // EOF (-1) and first time '=' character is encountered in stream.
+        // This approach makes the '=' padding characters completely optional.
+        if (context.eof && context.modulus > 0) { // if modulus == 0, nothing to do
+            final byte[] buffer = ensureBufferSize(decodeSize, context);
+            // We ignore partial bytes, i.e. only multiples of 8 count.
+            // Any combination not part of a valid encoding is either partially decoded
+            // or will raise an exception. Possible trailing characters are 2, 4, 5, 7.
+            // It is not possible to encode with 1, 3, 6 trailing characters.
+            // For backwards compatibility 3 & 6 chars are decoded anyway rather than discarded.
+            // See the encode(byte[]) method EOF section.
+            switch (context.modulus) {
+//              case 0 : // impossible, as excluded above
+            case 1: // 5 bits - either ignore entirely, or raise an exception
+                validateTrailingCharacters();
+                // falls-through
+            case 2: // 10 bits, drop 2 and output one byte
+                validateCharacter(MASK_2_BITS, context);
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 2 & MASK_8BITS);
+                break;
+            case 3: // 15 bits, drop 7 and output 1 byte, or raise an exception
+                validateTrailingCharacters();
+                // Not possible from a valid encoding but decode anyway
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 7 & MASK_8BITS);
+                break;
+            case 4: // 20 bits = 2*8 + 4
+                validateCharacter(MASK_4_BITS, context);
+                context.lbitWorkArea = context.lbitWorkArea >> 4; // drop 4 bits
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 8 & MASK_8BITS);
+                buffer[context.pos++] = (byte) (context.lbitWorkArea & MASK_8BITS);
+                break;
+            case 5: // 25 bits = 3*8 + 1
+                validateCharacter(MASK_1_BITS, context);
+                context.lbitWorkArea = context.lbitWorkArea >> 1;
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 16 & MASK_8BITS);
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 8 & MASK_8BITS);
+                buffer[context.pos++] = (byte) (context.lbitWorkArea & MASK_8BITS);
+                break;
+            case 6: // 30 bits = 3*8 + 6, or raise an exception
+                validateTrailingCharacters();
+                // Not possible from a valid encoding but decode anyway
+                context.lbitWorkArea = context.lbitWorkArea >> 6;
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 16 & MASK_8BITS);
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 8 & MASK_8BITS);
+                buffer[context.pos++] = (byte) (context.lbitWorkArea & MASK_8BITS);
+                break;
+            case 7: // 35 bits = 4*8 +3
+                validateCharacter(MASK_3_BITS, context);
+                context.lbitWorkArea = context.lbitWorkArea >> 3;
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 24 & MASK_8BITS);
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 16 & MASK_8BITS);
+                buffer[context.pos++] = (byte) (context.lbitWorkArea >> 8 & MASK_8BITS);
+                buffer[context.pos++] = (byte) (context.lbitWorkArea & MASK_8BITS);
+                break;
+            default:
+                // modulus can be 0-7, and we excluded 0,1 already
+                throw new IllegalStateException("Impossible modulus " + context.modulus);
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Encodes all of the provided data, starting at inPos, for inAvail bytes. Must be called at least twice: once with the data to encode, and once with
+     * inAvail set to "-1" to alert encoder that EOF has been reached, so flush last remaining bytes (if not multiple of 5).
+     * </p>
+     *
+     * @param input   byte[] array of binary data to Base32 encode.
+     * @param inPos   Position to start reading data from.
+     * @param inAvail Amount of bytes available from input for encoding.
+     * @param context the context to be used.
+     */
+    @Override
+    void encode(final byte[] input, int inPos, final int inAvail, final Context context) {
+        // package protected for access from I/O streams
+        if (context.eof) {
+            return;
+        }
+        // inAvail < 0 is how we're informed of EOF in the underlying data we're
+        // encoding.
+        if (inAvail < 0) {
+            context.eof = true;
+            if (0 == context.modulus && lineLength == 0) {
+                return; // no leftovers to process and not using chunking
+            }
+            final byte[] buffer = ensureBufferSize(encodeSize, context);
+            final int savedPos = context.pos;
+            switch (context.modulus) { // % 5
+            case 0:
+                break;
+            case 1: // Only 1 octet; take top 5 bits then remainder
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 3) & MASK_5_BITS]; // 8-1*5 = 3
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea << 2) & MASK_5_BITS]; // 5-3=2
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                break;
+            case 2: // 2 octets = 16 bits to use
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 11) & MASK_5_BITS]; // 16-1*5 = 11
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 6) & MASK_5_BITS]; // 16-2*5 = 6
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 1) & MASK_5_BITS]; // 16-3*5 = 1
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea << 4) & MASK_5_BITS]; // 5-1 = 4
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                break;
+            case 3: // 3 octets = 24 bits to use
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 19) & MASK_5_BITS]; // 24-1*5 = 19
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 14) & MASK_5_BITS]; // 24-2*5 = 14
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 9) & MASK_5_BITS]; // 24-3*5 = 9
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 4) & MASK_5_BITS]; // 24-4*5 = 4
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea << 1) & MASK_5_BITS]; // 5-4 = 1
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                buffer[context.pos++] = pad;
+                break;
+            case 4: // 4 octets = 32 bits to use
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 27) & MASK_5_BITS]; // 32-1*5 = 27
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 22) & MASK_5_BITS]; // 32-2*5 = 22
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 17) & MASK_5_BITS]; // 32-3*5 = 17
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 12) & MASK_5_BITS]; // 32-4*5 = 12
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 7) & MASK_5_BITS]; // 32-5*5 = 7
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 2) & MASK_5_BITS]; // 32-6*5 = 2
+                buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea << 3) & MASK_5_BITS]; // 5-2 = 3
+                buffer[context.pos++] = pad;
+                break;
+            default:
+                throw new IllegalStateException("Impossible modulus " + context.modulus);
+            }
+            context.currentLinePos += context.pos - savedPos; // keep track of current line position
+            // if currentPos == 0 we are at the start of a line, so don't add CRLF
+            if (lineLength > 0 && context.currentLinePos > 0) { // add chunk separator if required
+                System.arraycopy(lineSeparator, 0, buffer, context.pos, lineSeparator.length);
+                context.pos += lineSeparator.length;
+            }
+        } else {
+            for (int i = 0; i < inAvail; i++) {
+                final byte[] buffer = ensureBufferSize(encodeSize, context);
+                context.modulus = (context.modulus + 1) % BYTES_PER_UNENCODED_BLOCK;
+                int b = input[inPos++];
+                if (b < 0) {
+                    b += 256;
+                }
+                context.lbitWorkArea = (context.lbitWorkArea << 8) + b; // BITS_PER_BYTE
+                if (0 == context.modulus) { // we have enough bytes to create our output
+                    buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 35) & MASK_5_BITS];
+                    buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 30) & MASK_5_BITS];
+                    buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 25) & MASK_5_BITS];
+                    buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 20) & MASK_5_BITS];
+                    buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 15) & MASK_5_BITS];
+                    buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 10) & MASK_5_BITS];
+                    buffer[context.pos++] = encodeTable[(int) (context.lbitWorkArea >> 5) & MASK_5_BITS];
+                    buffer[context.pos++] = encodeTable[(int) context.lbitWorkArea & MASK_5_BITS];
+                    context.currentLinePos += BYTES_PER_ENCODED_BLOCK;
+                    if (lineLength > 0 && lineLength <= context.currentLinePos) {
+                        System.arraycopy(lineSeparator, 0, buffer, context.pos, lineSeparator.length);
+                        context.pos += lineSeparator.length;
+                        context.currentLinePos = 0;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the line separator (for testing only).
+     *
+     * @return the line separator.
+     */
+    byte[] getLineSeparator() {
+        return lineSeparator;
+    }
+
+    /**
+     * Returns whether or not the {@code octet} is in the Base32 alphabet.
+     *
+     * @param octet The value to test.
+     * @return {@code true} if the value is defined in the Base32 alphabet {@code false} otherwise.
+     */
+    @Override
+    public boolean isInAlphabet(final byte octet) {
+        return octet >= 0 && octet < decodeTable.length && decodeTable[octet] != -1;
+    }
+
+    /**
+     * Validates whether decoding the final trailing character is possible in the context of the set of possible Base32 values.
+     * <p>
+     * The character is valid if the lower bits within the provided mask are zero. This is used to test the final trailing base-32 digit is zero in the bits
+     * that will be discarded.
+     * </p>
+     *
+     * @param emptyBitsMask The mask of the lower bits that should be empty.
+     * @param context       the context to be used.
+     * @throws IllegalArgumentException if the bits being checked contain any non-zero value.
+     */
+    private void validateCharacter(final long emptyBitsMask, final Context context) {
+        // Use the long bit work area
+        if (isStrictDecoding() && (context.lbitWorkArea & emptyBitsMask) != 0) {
+            throw new IllegalArgumentException("Strict decoding: Last encoded character (before the paddings if any) is a valid " +
+                    "Base32 alphabet but not a possible encoding. Expected the discarded bits from the character to be zero.");
+        }
+    }
+
+    /**
+     * Validates whether decoding allows final trailing characters that cannot be created during encoding.
+     *
+     * @throws IllegalArgumentException if strict decoding is enabled.
+     */
+    private void validateTrailingCharacters() {
+        if (isStrictDecoding()) {
+            throw new IllegalArgumentException("Strict decoding: Last encoded character(s) (before the paddings if any) are valid " +
+                    "Base32 alphabet but not a possible encoding. Decoding requires either 2, 4, 5, or 7 trailing 5-bit characters to create bytes.");
+        }
+    }
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/BaseNCodec.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/BaseNCodec.java
@@ -1,0 +1,901 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec.binary;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import org.apache.commons.codec.BinaryDecoder;
+import org.apache.commons.codec.BinaryEncoder;
+import org.apache.commons.codec.CodecPolicy;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.EncoderException;
+
+/**
+ * Abstract superclass for Base-N encoders and decoders.
+ *
+ * <p>
+ * This class is thread-safe.
+ * </p>
+ * <p>
+ * You can set the decoding behavior when the input bytes contain leftover trailing bits that cannot be created by a valid encoding. These can be bits that are
+ * unused from the final character or entire characters. The default mode is lenient decoding.
+ * </p>
+ * <ul>
+ * <li>Lenient: Any trailing bits are composed into 8-bit bytes where possible. The remainder are discarded.</li>
+ * <li>Strict: The decoding will raise an {@link IllegalArgumentException} if trailing bits are not part of a valid encoding. Any unused bits from the final
+ * character must be zero. Impossible counts of entire final characters are not allowed.</li>
+ * </ul>
+ * <p>
+ * When strict decoding is enabled it is expected that the decoded bytes will be re-encoded to a byte array that matches the original, i.e. no changes occur on
+ * the final character. This requires that the input bytes use the same padding and alphabet as the encoder.
+ * </p>
+ */
+public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
+
+    /**
+     * Builds {@link Base64} instances.
+     *
+     * @param <T> the codec type to build.
+     * @param <B> the codec builder subtype.
+     * @since 1.17.0
+     */
+    public abstract static class AbstractBuilder<T, B extends AbstractBuilder<T, B>> implements Supplier<T> {
+
+        private int unencodedBlockSize;
+        private int encodedBlockSize;
+        private CodecPolicy decodingPolicy = DECODING_POLICY_DEFAULT;
+        private int lineLength;
+        private byte[] lineSeparator = CHUNK_SEPARATOR;
+        private final byte[] defaultEncodeTable;
+        private byte[] encodeTable;
+        private byte[] decodeTable;
+
+        /** Padding byte. */
+        private byte padding = PAD_DEFAULT;
+
+        AbstractBuilder(final byte[] defaultEncodeTable) {
+            this.defaultEncodeTable = defaultEncodeTable;
+            this.encodeTable = defaultEncodeTable;
+        }
+
+        /**
+         * Returns this instance typed as the subclass type {@code B}.
+         * <p>
+         * This is the same as the expression:
+         * </p>
+         *
+         * <pre>
+         * (B) this
+         * </pre>
+         *
+         * @return {@code this} instance typed as the subclass type {@code B}.
+         */
+        @SuppressWarnings("unchecked")
+        B asThis() {
+            return (B) this;
+        }
+
+        byte[] getDecodeTable() {
+            return decodeTable;
+        }
+
+        CodecPolicy getDecodingPolicy() {
+            return decodingPolicy;
+        }
+
+        int getEncodedBlockSize() {
+            return encodedBlockSize;
+        }
+
+        byte[] getEncodeTable() {
+            return encodeTable;
+        }
+
+        int getLineLength() {
+            return lineLength;
+        }
+
+        byte[] getLineSeparator() {
+            return lineSeparator;
+        }
+
+        byte getPadding() {
+            return padding;
+        }
+
+        int getUnencodedBlockSize() {
+            return unencodedBlockSize;
+        }
+
+        /**
+         * Sets the decode table.
+         *
+         * @param decodeTable the decode table.
+         * @return {@code this} instance.
+         * @since 1.20.0
+         */
+        public B setDecodeTable(final byte[] decodeTable) {
+            this.decodeTable = decodeTable != null ? decodeTable.clone() : null;
+            return asThis();
+        }
+
+        /**
+         * Sets the decode table.
+         *
+         * @param decodeTable the decode table, null resets to the default.
+         * @return {@code this} instance.
+         */
+        B setDecodeTableRaw(final byte[] decodeTable) {
+            this.decodeTable = decodeTable;
+            return asThis();
+        }
+
+        /**
+         * Sets the decoding policy.
+         *
+         * @param decodingPolicy the decoding policy, null resets to the default.
+         * @return {@code this} instance.
+         */
+        public B setDecodingPolicy(final CodecPolicy decodingPolicy) {
+            this.decodingPolicy = decodingPolicy != null ? decodingPolicy : DECODING_POLICY_DEFAULT;
+            return asThis();
+        }
+
+        /**
+         * Sets the encoded block size, subclasses normally set this on construction.
+         *
+         * @param encodedBlockSize the encoded block size, subclasses normally set this on construction.
+         * @return {@code this} instance.
+         */
+        B setEncodedBlockSize(final int encodedBlockSize) {
+            this.encodedBlockSize = encodedBlockSize;
+            return asThis();
+        }
+
+        /**
+         * Sets the encode table.
+         *
+         * @param encodeTable the encode table, null resets to the default.
+         * @return {@code this} instance.
+         */
+        public B setEncodeTable(final byte... encodeTable) {
+            this.encodeTable = encodeTable != null ? encodeTable.clone() : defaultEncodeTable;
+            return asThis();
+        }
+
+        /**
+         * Sets the encode table.
+         *
+         * @param encodeTable the encode table, null resets to the default.
+         * @return {@code this} instance.
+         */
+        B setEncodeTableRaw(final byte... encodeTable) {
+            this.encodeTable = encodeTable != null ? encodeTable : defaultEncodeTable;
+            return asThis();
+        }
+
+        /**
+         * Sets the line length.
+         *
+         * @param lineLength the line length, less than 0 resets to the default.
+         * @return {@code this} instance.
+         */
+        public B setLineLength(final int lineLength) {
+            this.lineLength = Math.max(0, lineLength);
+            return asThis();
+        }
+
+        /**
+         * Sets the line separator.
+         *
+         * @param lineSeparator the line separator, null resets to the default.
+         * @return {@code this} instance.
+         */
+        public B setLineSeparator(final byte... lineSeparator) {
+            this.lineSeparator = lineSeparator != null ? lineSeparator.clone() : CHUNK_SEPARATOR;
+            return asThis();
+        }
+
+        /**
+         * Sets the padding byte.
+         *
+         * @param padding the padding byte.
+         * @return {@code this} instance.
+         */
+        public B setPadding(final byte padding) {
+            this.padding = padding;
+            return asThis();
+        }
+
+        /**
+         * Sets the unencoded block size, subclasses normally set this on construction.
+         *
+         * @param unencodedBlockSize the unencoded block size, subclasses normally set this on construction.
+         * @return {@code this} instance.
+         */
+        B setUnencodedBlockSize(final int unencodedBlockSize) {
+            this.unencodedBlockSize = unencodedBlockSize;
+            return asThis();
+        }
+    }
+
+    /**
+     * Holds thread context so classes can be thread-safe.
+     *
+     * This class is not itself thread-safe; each thread must allocate its own copy.
+     */
+    static class Context {
+
+        /**
+         * Placeholder for the bytes we're dealing with for our based logic. Bitwise operations store and extract the encoding or decoding from this variable.
+         */
+        int ibitWorkArea;
+
+        /**
+         * Placeholder for the bytes we're dealing with for our based logic. Bitwise operations store and extract the encoding or decoding from this variable.
+         */
+        long lbitWorkArea;
+
+        /**
+         * Buffer for streaming.
+         */
+        byte[] buffer;
+
+        /**
+         * Position where next character should be written in the buffer.
+         */
+        int pos;
+
+        /**
+         * Position where next character should be read from the buffer.
+         */
+        int readPos;
+
+        /**
+         * Boolean flag to indicate the EOF has been reached. Once EOF has been reached, this object becomes useless, and must be thrown away.
+         */
+        boolean eof;
+
+        /**
+         * Variable tracks how many characters have been written to the current line. Only used when encoding. We use it to make sure each encoded line never
+         * goes beyond lineLength (if lineLength &gt; 0).
+         */
+        int currentLinePos;
+
+        /**
+         * Writes to the buffer only occur after every 3/5 reads when encoding, and every 4/8 reads when decoding. This variable helps track that.
+         */
+        int modulus;
+
+        /**
+         * Returns a String useful for debugging (especially within a debugger.)
+         *
+         * @return a String useful for debugging.
+         */
+        @Override
+        public String toString() {
+            return String.format("%s[buffer=%s, currentLinePos=%s, eof=%s, ibitWorkArea=%s, lbitWorkArea=%s, " + "modulus=%s, pos=%s, readPos=%s]",
+                    this.getClass().getSimpleName(), Arrays.toString(buffer), currentLinePos, eof, ibitWorkArea, lbitWorkArea, modulus, pos, readPos);
+        }
+    }
+
+    /**
+     * End-of-file marker.
+     *
+     * @since 1.7
+     */
+    static final int EOF = -1;
+
+    /**
+     * MIME chunk size per RFC 2045 section 6.8.
+     *
+     * <p>
+     * The {@value} character limit does not count the trailing CRLF, but counts all other characters, including any equal signs.
+     * </p>
+     *
+     * @see <a href="https://www.ietf.org/rfc/rfc2045">RFC 2045 section 6.8</a>
+     */
+    public static final int MIME_CHUNK_SIZE = 76;
+
+    /**
+     * PEM chunk size per RFC 1421 section 4.3.2.4.
+     *
+     * <p>
+     * The {@value} character limit does not count the trailing CRLF, but counts all other characters, including any equal signs.
+     * </p>
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc1421">RFC 1421 section 4.3.2.4</a>
+     */
+    public static final int PEM_CHUNK_SIZE = 64;
+    private static final int DEFAULT_BUFFER_RESIZE_FACTOR = 2;
+
+    /**
+     * Defines the default buffer size - currently {@value} - must be large enough for at least one encoded block+separator
+     */
+    private static final int DEFAULT_BUFFER_SIZE = 8192;
+
+    /**
+     * The maximum size buffer to allocate.
+     *
+     * <p>
+     * This is set to the same size used in the JDK {@link java.util.ArrayList}:
+     * </p>
+     * <blockquote> Some VMs reserve some header words in an array. Attempts to allocate larger arrays may result in OutOfMemoryError: Requested array size
+     * exceeds VM limit. </blockquote>
+     */
+    private static final int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
+
+    /** Mask used to extract 8 bits, used in decoding bytes */
+    protected static final int MASK_8BITS = 0xff;
+
+    /**
+     * Byte used to pad output.
+     */
+    protected static final byte PAD_DEFAULT = '='; // Allow static access to default
+
+    /**
+     * The default decoding policy.
+     *
+     * @since 1.15
+     */
+    protected static final CodecPolicy DECODING_POLICY_DEFAULT = CodecPolicy.LENIENT;
+
+    /**
+     * Chunk separator per RFC 2045 section 2.1.
+     *
+     * @see <a href="https://www.ietf.org/rfc/rfc2045">RFC 2045 section 2.1</a>
+     */
+    static final byte[] CHUNK_SEPARATOR = { '\r', '\n' };
+
+    /**
+     * The empty byte array.
+     */
+    static final byte[] EMPTY_BYTE_ARRAY = {};
+
+    /**
+     * Create a positive capacity at least as large the minimum required capacity. If the minimum capacity is negative then this throws an OutOfMemoryError as
+     * no array can be allocated.
+     *
+     * @param minCapacity the minimum capacity.
+     * @return the capacity.
+     * @throws OutOfMemoryError if the {@code minCapacity} is negative.
+     */
+    private static int createPositiveCapacity(final int minCapacity) {
+        if (minCapacity < 0) {
+            // overflow
+            throw new OutOfMemoryError("Unable to allocate array size: " + (minCapacity & 0xffffffffL));
+        }
+        // This is called when we require buffer expansion to a very big array.
+        // Use the conservative maximum buffer size if possible, otherwise the biggest required.
+        //
+        // Note: In this situation JDK 1.8 java.util.ArrayList returns Integer.MAX_VALUE.
+        // This excludes some VMs that can exceed MAX_BUFFER_SIZE but not allocate a full
+        // Integer.MAX_VALUE length array.
+        // The result is that we may have to allocate an array of this size more than once if
+        // the capacity must be expanded again.
+        return Math.max(minCapacity, MAX_BUFFER_SIZE);
+    }
+
+    /**
+     * Gets a copy of the chunk separator per RFC 2045 section 2.1.
+     *
+     * @return the chunk separator.
+     * @see <a href="https://www.ietf.org/rfc/rfc2045">RFC 2045 section 2.1</a>
+     * @since 1.15
+     */
+    public static byte[] getChunkSeparator() {
+        return CHUNK_SEPARATOR.clone();
+    }
+
+    /**
+     * Gets the array length or 0 if null.
+     *
+     * @param array the array or null.
+     * @return the array length or 0 if null.
+     */
+    static int getLength(final byte[] array) {
+        return array == null ? 0 : array.length;
+    }
+
+    /**
+     * Checks if a byte value is whitespace or not.
+     *
+     * @param byteToCheck the byte to check.
+     * @return true if byte is whitespace, false otherwise.
+     * @see Character#isWhitespace(int)
+     * @deprecated Use {@link Character#isWhitespace(int)}.
+     */
+    @Deprecated
+    protected static boolean isWhiteSpace(final byte byteToCheck) {
+        return Character.isWhitespace(byteToCheck);
+    }
+
+    /**
+     * Increases our buffer by the {@link #DEFAULT_BUFFER_RESIZE_FACTOR}.
+     *
+     * @param context     the context to be used.
+     * @param minCapacity the minimum required capacity.
+     * @return the resized byte[] buffer.
+     * @throws OutOfMemoryError if the {@code minCapacity} is negative.
+     */
+    private static byte[] resizeBuffer(final Context context, final int minCapacity) {
+        // Overflow-conscious code treats the min and new capacity as unsigned.
+        final int oldCapacity = context.buffer.length;
+        int newCapacity = oldCapacity * DEFAULT_BUFFER_RESIZE_FACTOR;
+        if (Integer.compareUnsigned(newCapacity, minCapacity) < 0) {
+            newCapacity = minCapacity;
+        }
+        if (Integer.compareUnsigned(newCapacity, MAX_BUFFER_SIZE) > 0) {
+            newCapacity = createPositiveCapacity(minCapacity);
+        }
+        final byte[] b = Arrays.copyOf(context.buffer, newCapacity);
+        context.buffer = b;
+        return b;
+    }
+
+    /**
+     * Deprecated: Will be removed in 2.0.
+     * <p>
+     * Instance variable just in case it needs to vary later
+     * </p>
+     *
+     * @deprecated Use {@link #pad}. Will be removed in 2.0.
+     */
+    @Deprecated
+    protected final byte PAD = PAD_DEFAULT;
+
+    /** Pad byte. Instance variable just in case it needs to vary later. */
+    protected final byte pad;
+
+    /** Number of bytes in each full block of unencoded data, for example 4 for Base64 and 5 for Base32 */
+    private final int unencodedBlockSize;
+
+    /** Number of bytes in each full block of encoded data, for example 3 for Base64 and 8 for Base32 */
+    private final int encodedBlockSize;
+
+    /**
+     * Chunksize for encoding. Not used when decoding. A value of zero or less implies no chunking of the encoded data. Rounded down to the nearest multiple of
+     * encodedBlockSize.
+     */
+    protected final int lineLength;
+
+    /**
+     * Size of chunk separator. Not used unless {@link #lineLength} &gt; 0.
+     */
+    private final int chunkSeparatorLength;
+
+    /**
+     * Defines the decoding behavior when the input bytes contain leftover trailing bits that cannot be created by a valid encoding. These can be bits that are
+     * unused from the final character or entire characters. The default mode is lenient decoding. Set this to {@code true} to enable strict decoding.
+     * <ul>
+     * <li>Lenient: Any trailing bits are composed into 8-bit bytes where possible. The remainder are discarded.</li>
+     * <li>Strict: The decoding will raise an {@link IllegalArgumentException} if trailing bits are not part of a valid encoding. Any unused bits from the final
+     * character must be zero. Impossible counts of entire final characters are not allowed.</li>
+     * </ul>
+     * <p>
+     * When strict decoding is enabled it is expected that the decoded bytes will be re-encoded to a byte array that matches the original, i.e. no changes occur
+     * on the final character. This requires that the input bytes use the same padding and alphabet as the encoder.
+     * </p>
+     */
+    private final CodecPolicy decodingPolicy;
+
+    /**
+     * Decode table to use.
+     */
+    final byte[] decodeTable;
+
+    /**
+     * Encode table.
+     */
+    final byte[] encodeTable;
+
+    /**
+     * Constructs a new instance for a subclass.
+     *
+     * @param builder How to build this portion of the instance.
+     * @since 1.20.0
+     */
+    protected BaseNCodec(final AbstractBuilder<?, ?> builder) {
+        this.unencodedBlockSize = builder.unencodedBlockSize;
+        this.encodedBlockSize = builder.encodedBlockSize;
+        final boolean useChunking = builder.lineLength > 0 && builder.lineSeparator.length > 0;
+        this.lineLength = useChunking ? builder.lineLength / builder.encodedBlockSize * builder.encodedBlockSize : 0;
+        this.chunkSeparatorLength = builder.lineSeparator.length;
+        this.pad = builder.padding;
+        this.decodingPolicy = Objects.requireNonNull(builder.decodingPolicy, "codecPolicy");
+        this.encodeTable = Objects.requireNonNull(builder.getEncodeTable(), "builder.getEncodeTable()");
+        this.decodeTable = builder.getDecodeTable();
+    }
+
+    /**
+     * Constructs a new instance.
+     * <p>
+     * Note {@code lineLength} is rounded down to the nearest multiple of the encoded block size. If {@code chunkSeparatorLength} is zero, then chunking is
+     * disabled.
+     * </p>
+     *
+     * @param unencodedBlockSize   the size of an unencoded block (for example Base64 = 3).
+     * @param encodedBlockSize     the size of an encoded block (for example Base64 = 4).
+     * @param lineLength           if &gt; 0, use chunking with a length {@code lineLength}.
+     * @param chunkSeparatorLength the chunk separator length, if relevant.
+     * @deprecated Use {@link BaseNCodec#BaseNCodec(AbstractBuilder)}.
+     */
+    @Deprecated
+    protected BaseNCodec(final int unencodedBlockSize, final int encodedBlockSize, final int lineLength, final int chunkSeparatorLength) {
+        this(unencodedBlockSize, encodedBlockSize, lineLength, chunkSeparatorLength, PAD_DEFAULT);
+    }
+
+    /**
+     * Constructs a new instance.
+     * <p>
+     * Note {@code lineLength} is rounded down to the nearest multiple of the encoded block size. If {@code chunkSeparatorLength} is zero, then chunking is
+     * disabled.
+     * </p>
+     *
+     * @param unencodedBlockSize   the size of an unencoded block (for example Base64 = 3).
+     * @param encodedBlockSize     the size of an encoded block (for example Base64 = 4).
+     * @param lineLength           if &gt; 0, use chunking with a length {@code lineLength}.
+     * @param chunkSeparatorLength the chunk separator length, if relevant.
+     * @param pad                  byte used as padding byte.
+     * @deprecated Use {@link BaseNCodec#BaseNCodec(AbstractBuilder)}.
+     */
+    @Deprecated
+    protected BaseNCodec(final int unencodedBlockSize, final int encodedBlockSize, final int lineLength, final int chunkSeparatorLength, final byte pad) {
+        this(unencodedBlockSize, encodedBlockSize, lineLength, chunkSeparatorLength, pad, DECODING_POLICY_DEFAULT);
+    }
+
+    /**
+     * Constructs a new instance.
+     * <p>
+     * Note {@code lineLength} is rounded down to the nearest multiple of the encoded block size. If {@code chunkSeparatorLength} is zero, then chunking is
+     * disabled.
+     * </p>
+     *
+     * @param unencodedBlockSize   the size of an unencoded block (for example Base64 = 3).
+     * @param encodedBlockSize     the size of an encoded block (for example Base64 = 4).
+     * @param lineLength           if &gt; 0, use chunking with a length {@code lineLength}.
+     * @param chunkSeparatorLength the chunk separator length, if relevant.
+     * @param pad                  byte used as padding byte.
+     * @param decodingPolicy       Decoding policy.
+     * @since 1.15
+     * @deprecated Use {@link BaseNCodec#BaseNCodec(AbstractBuilder)}.
+     */
+    @Deprecated
+    protected BaseNCodec(final int unencodedBlockSize, final int encodedBlockSize, final int lineLength, final int chunkSeparatorLength, final byte pad,
+            final CodecPolicy decodingPolicy) {
+        this.unencodedBlockSize = unencodedBlockSize;
+        this.encodedBlockSize = encodedBlockSize;
+        final boolean useChunking = lineLength > 0 && chunkSeparatorLength > 0;
+        this.lineLength = useChunking ? lineLength / encodedBlockSize * encodedBlockSize : 0;
+        this.chunkSeparatorLength = chunkSeparatorLength;
+        this.pad = pad;
+        this.decodingPolicy = Objects.requireNonNull(decodingPolicy, "codecPolicy");
+        this.encodeTable = null;
+        this.decodeTable = null;
+    }
+
+    /**
+     * Returns the amount of buffered data available for reading.
+     *
+     * @param context the context to be used.
+     * @return The amount of buffered data available for reading.
+     */
+    int available(final Context context) { // package protected for access from I/O streams
+        return hasData(context) ? context.pos - context.readPos : 0;
+    }
+
+    /**
+     * Tests a given byte array to see if it contains any characters within the alphabet or PAD.
+     *
+     * Intended for use in checking line-ending arrays.
+     *
+     * @param arrayOctet byte array to test.
+     * @return {@code true} if any byte is a valid character in the alphabet or PAD; {@code false} otherwise.
+     */
+    protected boolean containsAlphabetOrPad(final byte[] arrayOctet) {
+        if (arrayOctet != null) {
+            for (final byte element : arrayOctet) {
+                if (pad == element || isInAlphabet(element)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Decodes a byte[] containing characters in the Base-N alphabet.
+     *
+     * @param array A byte array containing Base-N character data.
+     * @return a byte array containing binary data.
+     */
+    @Override
+    public byte[] decode(final byte[] array) {
+        if (BinaryCodec.isEmpty(array)) {
+            return array;
+        }
+        final Context context = new Context();
+        decode(array, 0, array.length, context);
+        decode(array, 0, EOF, context); // Notify decoder of EOF.
+        final byte[] result = new byte[context.pos];
+        readResults(result, 0, result.length, context);
+        return result;
+    }
+
+    // package protected for access from I/O streams
+    abstract void decode(byte[] array, int i, int length, Context context);
+
+    /**
+     * Decodes an Object using the Base-N algorithm. This method is provided in order to satisfy the requirements of the Decoder interface, and will throw a
+     * DecoderException if the supplied object is not of type byte[] or String.
+     *
+     * @param obj Object to decode.
+     * @return An object (of type byte[]) containing the binary data which corresponds to the byte[] or String supplied.
+     * @throws DecoderException if the parameter supplied is not of type byte[].
+     */
+    @Override
+    public Object decode(final Object obj) throws DecoderException {
+        if (obj instanceof byte[]) {
+            return decode((byte[]) obj);
+        }
+        if (obj instanceof String) {
+            return decode((String) obj);
+        }
+        throw new DecoderException("Parameter supplied to Base-N decode is not a byte[] or a String");
+    }
+
+    /**
+     * Decodes a String containing characters in the Base-N alphabet.
+     *
+     * @param array A String containing Base-N character data.
+     * @return a byte array containing binary data.
+     */
+    public byte[] decode(final String array) {
+        return decode(StringUtils.getBytesUtf8(array));
+    }
+
+    /**
+     * Encodes a byte[] containing binary data, into a byte[] containing characters in the alphabet.
+     *
+     * @param array a byte array containing binary data.
+     * @return A byte array containing only the base N alphabetic character data.
+     */
+    @Override
+    public byte[] encode(final byte[] array) {
+        if (BinaryCodec.isEmpty(array)) {
+            return array;
+        }
+        return encode(array, 0, array.length);
+    }
+
+    /**
+     * Encodes a byte[] containing binary data, into a byte[] containing characters in the alphabet.
+     *
+     * @param array  a byte array containing binary data.
+     * @param offset initial offset of the subarray.
+     * @param length length of the subarray.
+     * @return A byte array containing only the base N alphabetic character data.
+     * @since 1.11
+     */
+    public byte[] encode(final byte[] array, final int offset, final int length) {
+        if (BinaryCodec.isEmpty(array)) {
+            return array;
+        }
+        final Context context = new Context();
+        encode(array, offset, length, context);
+        encode(array, offset, EOF, context); // Notify encoder of EOF.
+        final byte[] buf = new byte[context.pos - context.readPos];
+        readResults(buf, 0, buf.length, context);
+        return buf;
+    }
+
+    // package protected for access from I/O streams
+    abstract void encode(byte[] array, int i, int length, Context context);
+
+    /**
+     * Encodes an Object using the Base-N algorithm. This method is provided in order to satisfy the requirements of the Encoder interface, and will throw an
+     * EncoderException if the supplied object is not of type byte[].
+     *
+     * @param obj Object to encode.
+     * @return An object (of type byte[]) containing the Base-N encoded data which corresponds to the byte[] supplied.
+     * @throws EncoderException if the parameter supplied is not of type byte[].
+     */
+    @Override
+    public Object encode(final Object obj) throws EncoderException {
+        if (!(obj instanceof byte[])) {
+            throw new EncoderException("Parameter supplied to Base-N encode is not a byte[]");
+        }
+        return encode((byte[]) obj);
+    }
+
+    /**
+     * Encodes a byte[] containing binary data, into a String containing characters in the appropriate alphabet. Uses UTF8 encoding.
+     * <p>
+     * This is a duplicate of {@link #encodeToString(byte[])}; it was merged during refactoring.
+     * </p>
+     *
+     * @param array a byte array containing binary data.
+     * @return String containing only character data in the appropriate alphabet.
+     * @since 1.5
+     */
+    public String encodeAsString(final byte[] array) {
+        return StringUtils.newStringUtf8(encode(array));
+    }
+
+    /**
+     * Encodes a byte[] containing binary data, into a String containing characters in the Base-N alphabet. Uses UTF8 encoding.
+     *
+     * @param array a byte array containing binary data.
+     * @return A String containing only Base-N character data.
+     */
+    public String encodeToString(final byte[] array) {
+        return StringUtils.newStringUtf8(encode(array));
+    }
+
+    /**
+     * Ensures that the buffer has room for {@code size} bytes
+     *
+     * @param size    minimum spare space required.
+     * @param context the context to be used.
+     * @return the buffer.
+     */
+    protected byte[] ensureBufferSize(final int size, final Context context) {
+        if (context.buffer == null) {
+            context.buffer = new byte[Math.max(size, getDefaultBufferSize())];
+            context.pos = 0;
+            context.readPos = 0;
+            // Overflow-conscious:
+            // x + y > z == x + y - z > 0
+        } else if (context.pos + size - context.buffer.length > 0) {
+            return resizeBuffer(context, context.pos + size);
+        }
+        return context.buffer;
+    }
+
+    /**
+     * Gets the decoding behavior policy.
+     *
+     * <p>
+     * The default is lenient. If the decoding policy is strict, then decoding will raise an {@link IllegalArgumentException} if trailing bits are not part of a
+     * valid encoding. Decoding will compose trailing bits into 8-bit bytes and discard the remainder.
+     * </p>
+     *
+     * @return true if using strict decoding.
+     * @since 1.15
+     */
+    public CodecPolicy getCodecPolicy() {
+        return decodingPolicy;
+    }
+
+    /**
+     * Gets the default buffer size. Can be overridden.
+     *
+     * @return the default buffer size.
+     */
+    protected int getDefaultBufferSize() {
+        return DEFAULT_BUFFER_SIZE;
+    }
+
+    /**
+     * Gets the amount of space needed to encode the supplied array.
+     *
+     * @param array byte[] array which will later be encoded.
+     * @return amount of space needed to encode the supplied array. Returns a long since a max-len array will require &gt; Integer.MAX_VALUE.
+     */
+    public long getEncodedLength(final byte[] array) {
+        // Calculate non-chunked size - rounded up to allow for padding
+        // cast to long is needed to avoid possibility of overflow
+        long len = (array.length + unencodedBlockSize - 1) / unencodedBlockSize * (long) encodedBlockSize;
+        if (lineLength > 0) { // We're using chunking
+            // Round up to nearest multiple
+            len += (len + lineLength - 1) / lineLength * chunkSeparatorLength;
+        }
+        return len;
+    }
+
+    /**
+     * Tests whether this object has buffered data for reading.
+     *
+     * @param context the context to be used.
+     * @return true if there is data still available for reading.
+     */
+    boolean hasData(final Context context) { // package protected for access from I/O streams
+        return context.pos > context.readPos;
+    }
+
+    /**
+     * Tests whether or not the {@code octet} is in the current alphabet. Does not allow whitespace or pad.
+     *
+     * @param value The value to test.
+     * @return {@code true} if the value is defined in the current alphabet, {@code false} otherwise.
+     */
+    protected abstract boolean isInAlphabet(byte value);
+
+    /**
+     * Tests a given byte array to see if it contains only valid characters within the alphabet. The method optionally treats whitespace and pad as valid.
+     *
+     * @param arrayOctet byte array to test.
+     * @param allowWSPad if {@code true}, then whitespace and PAD are also allowed.
+     * @return {@code true} if all bytes are valid characters in the alphabet or if the byte array is empty; {@code false}, otherwise.
+     */
+    public boolean isInAlphabet(final byte[] arrayOctet, final boolean allowWSPad) {
+        for (final byte octet : arrayOctet) {
+            if (!isInAlphabet(octet) && (!allowWSPad || octet != pad && !Character.isWhitespace(octet))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Tests a given String to see if it contains only valid characters within the alphabet. The method treats whitespace and PAD as valid.
+     *
+     * @param basen String to test.
+     * @return {@code true} if all characters in the String are valid characters in the alphabet or if the String is empty; {@code false}, otherwise.
+     * @see #isInAlphabet(byte[], boolean)
+     */
+    public boolean isInAlphabet(final String basen) {
+        return isInAlphabet(StringUtils.getBytesUtf8(basen), true);
+    }
+
+    /**
+     * Tests true if decoding behavior is strict. Decoding will raise an {@link IllegalArgumentException} if trailing bits are not part of a valid encoding.
+     *
+     * <p>
+     * The default is false for lenient decoding. Decoding will compose trailing bits into 8-bit bytes and discard the remainder.
+     * </p>
+     *
+     * @return true if using strict decoding.
+     * @since 1.15
+     */
+    public boolean isStrictDecoding() {
+        return decodingPolicy == CodecPolicy.STRICT;
+    }
+
+    /**
+     * Reads buffered data into the provided byte[] array, starting at position bPos, up to a maximum of bAvail bytes. Returns how many bytes were actually
+     * extracted.
+     * <p>
+     * Package private for access from I/O streams.
+     * </p>
+     *
+     * @param b       byte[] array to extract the buffered data into.
+     * @param bPos    position in byte[] array to start extraction at.
+     * @param bAvail  amount of bytes we're allowed to extract. We may extract fewer (if fewer are available).
+     * @param context the context to be used.
+     * @return The number of bytes successfully extracted into the provided byte[] array.
+     */
+    int readResults(final byte[] b, final int bPos, final int bAvail, final Context context) {
+        if (hasData(context)) {
+            final int len = Math.min(available(context), bAvail);
+            System.arraycopy(context.buffer, context.readPos, b, bPos, len);
+            context.readPos += len;
+            if (!hasData(context)) {
+                // All data read.
+                // Reset position markers but do not set buffer to null to allow its reuse.
+                // hasData(context) will still return false, and this method will return 0 until
+                // more data is available, or -1 if EOF.
+                context.pos = context.readPos = 0;
+            }
+            return len;
+        }
+        return context.eof ? EOF : 0;
+    }
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/BaseNCodec.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/BaseNCodec.java
@@ -13,19 +13,21 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec.binary;
+package com.jefftharris.commons.codec.binary;
 
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import org.apache.commons.codec.BinaryDecoder;
-import org.apache.commons.codec.BinaryEncoder;
-import org.apache.commons.codec.CodecPolicy;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.EncoderException;
+import com.jefftharris.commons.codec.BinaryDecoder;
+import com.jefftharris.commons.codec.BinaryEncoder;
+import com.jefftharris.commons.codec.CodecPolicy;
+import com.jefftharris.commons.codec.DecoderException;
+import com.jefftharris.commons.codec.EncoderException;
 
 /**
  * Abstract superclass for Base-N encoders and decoders.

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/BaseNCodec.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/BaseNCodec.java
@@ -21,7 +21,6 @@ package com.jefftharris.commons.codec.binary;
 
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.function.Supplier;
 
 import com.jefftharris.commons.codec.BinaryDecoder;
 import com.jefftharris.commons.codec.BinaryEncoder;
@@ -49,6 +48,11 @@ import com.jefftharris.commons.codec.EncoderException;
  * the final character. This requires that the input bytes use the same padding and alphabet as the encoder.
  * </p>
  */
+@SuppressWarnings({"WeakerAccess", "unused", "deprecation", "JavadocBlankLines",
+                   "SameParameterValue", "ClassEscapesDefinedScope",
+                   "MismatchedJavadocCode", "UnusedReturnValue",
+                   "SpellCheckingInspection", "GrazieStyle",
+                   "RedundantSuppression"})
 public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
 
     /**
@@ -58,7 +62,8 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
      * @param <B> the codec builder subtype.
      * @since 1.17.0
      */
-    public abstract static class AbstractBuilder<T, B extends AbstractBuilder<T, B>> implements Supplier<T> {
+    @SuppressWarnings({"JavadocReference", "unused", "UnusedReturnValue"})
+    public abstract static class AbstractBuilder<T, B extends AbstractBuilder<T, B>> {
 
         private int unencodedBlockSize;
         private int encodedBlockSize;
@@ -93,6 +98,13 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
         B asThis() {
             return (B) this;
         }
+
+        /**
+         * Gets a result.
+         *
+         * @return a result
+         */
+        abstract T get();
 
         byte[] getDecodeTable() {
             return decodeTable;
@@ -243,6 +255,7 @@ public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
      *
      * This class is not itself thread-safe; each thread must allocate its own copy.
      */
+    @SuppressWarnings({"JavadocBlankLines", "NullableProblems"})
     static class Context {
 
         /**

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/BinaryCodec.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/BinaryCodec.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec.binary;
+
+import org.apache.commons.codec.BinaryDecoder;
+import org.apache.commons.codec.BinaryEncoder;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.EncoderException;
+
+/**
+ * Converts between byte arrays and strings of "0"s and "1"s.
+ *
+ * <p>
+ * This class is immutable and thread-safe.
+ * </p>
+ *
+ * TODO: may want to add more bit vector functions like and/or/xor/nand TODO: also might be good to generate boolean[] from byte[] et cetera.
+ *
+ * @since 1.3
+ */
+public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
+
+    /*
+     * tried to avoid using ArrayUtils to minimize dependencies while using these empty arrays - dep is just not worth it.
+     */
+
+    /** Empty char array. */
+    private static final char[] EMPTY_CHAR_ARRAY = {};
+
+    /** Empty byte array. */
+    private static final byte[] EMPTY_BYTE_ARRAY = {};
+
+    /** Mask for bit 0 of a byte. */
+    private static final int BIT_0 = 1;
+
+    /** Mask for bit 1 of a byte. */
+    private static final int BIT_1 = 0x02;
+
+    /** Mask for bit 2 of a byte. */
+    private static final int BIT_2 = 0x04;
+
+    /** Mask for bit 3 of a byte. */
+    private static final int BIT_3 = 0x08;
+
+    /** Mask for bit 4 of a byte. */
+    private static final int BIT_4 = 0x10;
+
+    /** Mask for bit 5 of a byte. */
+    private static final int BIT_5 = 0x20;
+
+    /** Mask for bit 6 of a byte. */
+    private static final int BIT_6 = 0x40;
+
+    /** Mask for bit 7 of a byte. */
+    private static final int BIT_7 = 0x80;
+
+    private static final int[] BITS = { BIT_0, BIT_1, BIT_2, BIT_3, BIT_4, BIT_5, BIT_6, BIT_7 };
+
+    /**
+     * Decodes a byte array where each byte represents an ASCII '0' or '1'.
+     *
+     * @param ascii each byte represents an ASCII '0' or '1'.
+     * @return the raw encoded binary where each bit corresponds to a byte in the byte array argument.
+     */
+    public static byte[] fromAscii(final byte[] ascii) {
+        if (isEmpty(ascii)) {
+            return EMPTY_BYTE_ARRAY;
+        }
+        final int asciiLength = ascii.length;
+        // get length/8 times bytes with 3 bit shifts to the right of the length
+        final byte[] raw = new byte[asciiLength >> 3];
+        /*
+         * We decr index jj by 8 as we go along to not recompute indices using multiplication every time inside the loop.
+         */
+        for (int ii = 0, jj = asciiLength - 1; ii < raw.length; ii++, jj -= 8) {
+            for (int bits = 0; bits < BITS.length; ++bits) {
+                if (ascii[jj - bits] == '1') {
+                    raw[ii] |= BITS[bits];
+                }
+            }
+        }
+        return raw;
+    }
+
+    /**
+     * Decodes a char array where each char represents an ASCII '0' or '1'.
+     *
+     * @param ascii each char represents an ASCII '0' or '1'.
+     * @return the raw encoded binary where each bit corresponds to a char in the char array argument.
+     */
+    public static byte[] fromAscii(final char[] ascii) {
+        if (ascii == null || ascii.length == 0) {
+            return EMPTY_BYTE_ARRAY;
+        }
+        final int asciiLength = ascii.length;
+        // get length/8 times bytes with 3 bit shifts to the right of the length
+        final byte[] raw = new byte[asciiLength >> 3];
+        /*
+         * We decr index jj by 8 as we go along to not recompute indices using multiplication every time inside the loop.
+         */
+        for (int ii = 0, jj = asciiLength - 1; ii < raw.length; ii++, jj -= 8) {
+            for (int bits = 0; bits < BITS.length; ++bits) {
+                if (ascii[jj - bits] == '1') {
+                    raw[ii] |= BITS[bits];
+                }
+            }
+        }
+        return raw;
+    }
+
+    /**
+     * Returns {@code true} if the given array is {@code null} or empty (size 0.)
+     *
+     * @param array the source array.
+     * @return {@code true} if the given array is {@code null} or empty (size 0.)
+     */
+    static boolean isEmpty(final byte[] array) {
+        return array == null || array.length == 0;
+    }
+
+    /**
+     * Converts an array of raw binary data into an array of ASCII 0 and 1 character bytes - each byte is a truncated char.
+     *
+     * @param raw the raw binary data to convert.
+     * @return an array of 0 and 1 character bytes for each bit of the argument.
+     * @see org.apache.commons.codec.BinaryEncoder#encode(byte[])
+     */
+    public static byte[] toAsciiBytes(final byte[] raw) {
+        if (isEmpty(raw)) {
+            return EMPTY_BYTE_ARRAY;
+        }
+        final int rawLength = raw.length;
+        // get 8 times the bytes with 3 bit shifts to the left of the length
+        final byte[] ascii = new byte[rawLength << 3];
+        /*
+         * We decr index jj by 8 as we go along to not recompute indices using multiplication every time inside the loop.
+         */
+        for (int ii = 0, jj = ascii.length - 1; ii < rawLength; ii++, jj -= 8) {
+            for (int bits = 0; bits < BITS.length; ++bits) {
+                if ((raw[ii] & BITS[bits]) == 0) {
+                    ascii[jj - bits] = '0';
+                } else {
+                    ascii[jj - bits] = '1';
+                }
+            }
+        }
+        return ascii;
+    }
+
+    /**
+     * Converts an array of raw binary data into an array of ASCII 0 and 1 characters.
+     *
+     * @param raw the raw binary data to convert.
+     * @return an array of 0 and 1 characters for each bit of the argument.
+     * @see org.apache.commons.codec.BinaryEncoder#encode(byte[])
+     */
+    public static char[] toAsciiChars(final byte[] raw) {
+        if (isEmpty(raw)) {
+            return EMPTY_CHAR_ARRAY;
+        }
+        final int rawLength = raw.length;
+        // get 8 times the bytes with 3 bit shifts to the left of the length
+        final char[] ascii = new char[rawLength << 3];
+        /*
+         * We decr index jj by 8 as we go along to not recompute indices using multiplication every time inside the loop.
+         */
+        for (int ii = 0, jj = ascii.length - 1; ii < rawLength; ii++, jj -= 8) {
+            for (int bits = 0; bits < BITS.length; ++bits) {
+                if ((raw[ii] & BITS[bits]) == 0) {
+                    ascii[jj - bits] = '0';
+                } else {
+                    ascii[jj - bits] = '1';
+                }
+            }
+        }
+        return ascii;
+    }
+
+    /**
+     * Converts an array of raw binary data into a String of ASCII 0 and 1 characters.
+     *
+     * @param raw the raw binary data to convert.
+     * @return a String of 0 and 1 characters representing the binary data.
+     * @see org.apache.commons.codec.BinaryEncoder#encode(byte[])
+     */
+    public static String toAsciiString(final byte[] raw) {
+        return new String(toAsciiChars(raw));
+    }
+
+    /**
+     * Constructs a new instance.
+     */
+    public BinaryCodec() {
+        // empty
+    }
+
+    /**
+     * Decodes a byte array where each byte represents an ASCII '0' or '1'.
+     *
+     * @param ascii each byte represents an ASCII '0' or '1'.
+     * @return the raw encoded binary where each bit corresponds to a byte in the byte array argument.
+     * @see org.apache.commons.codec.Decoder#decode(Object)
+     */
+    @Override
+    public byte[] decode(final byte[] ascii) {
+        return fromAscii(ascii);
+    }
+
+    /**
+     * Decodes a byte array where each byte represents an ASCII '0' or '1'.
+     *
+     * @param ascii each byte represents an ASCII '0' or '1'.
+     * @return the raw encoded binary where each bit corresponds to a byte in the byte array argument.
+     * @throws DecoderException if argument is not a byte[], char[] or String.
+     * @see org.apache.commons.codec.Decoder#decode(Object)
+     */
+    @Override
+    public Object decode(final Object ascii) throws DecoderException {
+        if (ascii == null) {
+            return EMPTY_BYTE_ARRAY;
+        }
+        if (ascii instanceof byte[]) {
+            return fromAscii((byte[]) ascii);
+        }
+        if (ascii instanceof char[]) {
+            return fromAscii((char[]) ascii);
+        }
+        if (ascii instanceof String) {
+            return fromAscii(((String) ascii).toCharArray());
+        }
+        throw new DecoderException("argument not a byte array");
+    }
+
+    /**
+     * Converts an array of raw binary data into an array of ASCII 0 and 1 characters.
+     *
+     * @param raw the raw binary data to convert.
+     * @return 0 and 1 ASCII character bytes one for each bit of the argument.
+     * @see org.apache.commons.codec.BinaryEncoder#encode(byte[])
+     */
+    @Override
+    public byte[] encode(final byte[] raw) {
+        return toAsciiBytes(raw);
+    }
+
+    /**
+     * Converts an array of raw binary data into an array of ASCII 0 and 1 chars.
+     *
+     * @param raw the raw binary data to convert.
+     * @return 0 and 1 ASCII character chars one for each bit of the argument.
+     * @throws EncoderException if the argument is not a byte[].
+     * @see org.apache.commons.codec.Encoder#encode(Object)
+     */
+    @Override
+    public Object encode(final Object raw) throws EncoderException {
+        if (!(raw instanceof byte[])) {
+            throw new EncoderException("argument not a byte array");
+        }
+        return toAsciiChars((byte[]) raw);
+    }
+
+    /**
+     * Decodes a String where each char of the String represents an ASCII '0' or '1'.
+     *
+     * @param ascii String of '0' and '1' characters.
+     * @return the raw encoded binary where each bit corresponds to a byte in the byte array argument.
+     * @see org.apache.commons.codec.Decoder#decode(Object)
+     */
+    public byte[] toByteArray(final String ascii) {
+        if (ascii == null) {
+            return EMPTY_BYTE_ARRAY;
+        }
+        return fromAscii(ascii.toCharArray());
+    }
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/BinaryCodec.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/BinaryCodec.java
@@ -13,14 +13,16 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec.binary;
+package com.jefftharris.commons.codec.binary;
 
-import org.apache.commons.codec.BinaryDecoder;
-import org.apache.commons.codec.BinaryEncoder;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.EncoderException;
+import com.jefftharris.commons.codec.BinaryDecoder;
+import com.jefftharris.commons.codec.BinaryEncoder;
+import com.jefftharris.commons.codec.DecoderException;
+import com.jefftharris.commons.codec.EncoderException;
 
 /**
  * Converts between byte arrays and strings of "0"s and "1"s.
@@ -138,7 +140,7 @@ public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
      *
      * @param raw the raw binary data to convert.
      * @return an array of 0 and 1 character bytes for each bit of the argument.
-     * @see org.apache.commons.codec.BinaryEncoder#encode(byte[])
+     * @see com.jefftharris.commons.codec.BinaryEncoder#encode(byte[])
      */
     public static byte[] toAsciiBytes(final byte[] raw) {
         if (isEmpty(raw)) {
@@ -167,7 +169,7 @@ public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
      *
      * @param raw the raw binary data to convert.
      * @return an array of 0 and 1 characters for each bit of the argument.
-     * @see org.apache.commons.codec.BinaryEncoder#encode(byte[])
+     * @see com.jefftharris.commons.codec.BinaryEncoder#encode(byte[])
      */
     public static char[] toAsciiChars(final byte[] raw) {
         if (isEmpty(raw)) {
@@ -196,7 +198,7 @@ public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
      *
      * @param raw the raw binary data to convert.
      * @return a String of 0 and 1 characters representing the binary data.
-     * @see org.apache.commons.codec.BinaryEncoder#encode(byte[])
+     * @see com.jefftharris.commons.codec.BinaryEncoder#encode(byte[])
      */
     public static String toAsciiString(final byte[] raw) {
         return new String(toAsciiChars(raw));
@@ -214,7 +216,7 @@ public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
      *
      * @param ascii each byte represents an ASCII '0' or '1'.
      * @return the raw encoded binary where each bit corresponds to a byte in the byte array argument.
-     * @see org.apache.commons.codec.Decoder#decode(Object)
+     * @see com.jefftharris.commons.codec.Decoder#decode(Object)
      */
     @Override
     public byte[] decode(final byte[] ascii) {
@@ -227,7 +229,7 @@ public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
      * @param ascii each byte represents an ASCII '0' or '1'.
      * @return the raw encoded binary where each bit corresponds to a byte in the byte array argument.
      * @throws DecoderException if argument is not a byte[], char[] or String.
-     * @see org.apache.commons.codec.Decoder#decode(Object)
+     * @see com.jefftharris.commons.codec.Decoder#decode(Object)
      */
     @Override
     public Object decode(final Object ascii) throws DecoderException {
@@ -251,7 +253,7 @@ public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
      *
      * @param raw the raw binary data to convert.
      * @return 0 and 1 ASCII character bytes one for each bit of the argument.
-     * @see org.apache.commons.codec.BinaryEncoder#encode(byte[])
+     * @see com.jefftharris.commons.codec.BinaryEncoder#encode(byte[])
      */
     @Override
     public byte[] encode(final byte[] raw) {
@@ -264,7 +266,7 @@ public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
      * @param raw the raw binary data to convert.
      * @return 0 and 1 ASCII character chars one for each bit of the argument.
      * @throws EncoderException if the argument is not a byte[].
-     * @see org.apache.commons.codec.Encoder#encode(Object)
+     * @see com.jefftharris.commons.codec.Encoder#encode(Object)
      */
     @Override
     public Object encode(final Object raw) throws EncoderException {
@@ -279,7 +281,7 @@ public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
      *
      * @param ascii String of '0' and '1' characters.
      * @return the raw encoded binary where each bit corresponds to a byte in the byte array argument.
-     * @see org.apache.commons.codec.Decoder#decode(Object)
+     * @see com.jefftharris.commons.codec.Decoder#decode(Object)
      */
     public byte[] toByteArray(final String ascii) {
         if (ascii == null) {

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/BinaryCodec.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/BinaryCodec.java
@@ -31,10 +31,14 @@ import com.jefftharris.commons.codec.EncoderException;
  * This class is immutable and thread-safe.
  * </p>
  *
- * TODO: may want to add more bit vector functions like and/or/xor/nand TODO: also might be good to generate boolean[] from byte[] et cetera.
+ * TODOapache: may want to add more bit vector functions like and/or/xor/nand
+ * TODOapache: also might be good to generate boolean[] from byte[] et cetera.
  *
  * @since 1.3
  */
+@SuppressWarnings(
+        {"WeakerAccess", "lossy-conversions", "ImplicitNumericConversion",
+         "unused", "SpellCheckingInspection"})
 public class BinaryCodec implements BinaryDecoder, BinaryEncoder {
 
     /*

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/CharSequenceUtils.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/CharSequenceUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.codec.binary;
+
+/**
+ * <p>
+ * Operations on {@link CharSequence} that are {@code null} safe.
+ * </p>
+ * <p>
+ * Copied from Apache Commons Lang r1586295 on April 10, 2014 (day of 3.3.2 release).
+ * </p>
+ *
+ * @see CharSequence
+ * @since 1.10
+ */
+public class CharSequenceUtils {
+
+    /**
+     * Green implementation of regionMatches.
+     *
+     * <p>
+     * Note: This function differs from the current implementation in Apache Commons Lang where the input indices are not valid. It is only used within this
+     * package.
+     * </p>
+     *
+     * @param cs         the {@code CharSequence} to be processed.
+     * @param ignoreCase whether or not to be case-insensitive.
+     * @param thisStart  the index to start on the {@code cs} CharSequence.
+     * @param substring  the {@code CharSequence} to be looked for.
+     * @param start      the index to start on the {@code substring} CharSequence.
+     * @param length     character length of the region.
+     * @return whether the region matched.
+     */
+    static boolean regionMatches(final CharSequence cs, final boolean ignoreCase, final int thisStart,
+            final CharSequence substring, final int start, final int length) {
+        if (cs instanceof String && substring instanceof String) {
+            return ((String) cs).regionMatches(ignoreCase, thisStart, (String) substring, start, length);
+        }
+        int index1 = thisStart;
+        int index2 = start;
+        int tmpLen = length;
+        while (tmpLen-- > 0) {
+            final char c1 = cs.charAt(index1++);
+            final char c2 = substring.charAt(index2++);
+            if (c1 == c2) {
+                continue;
+            }
+            if (!ignoreCase) {
+                return false;
+            }
+            // The same check as in String.regionMatches():
+            if (Character.toUpperCase(c1) != Character.toUpperCase(c2) &&
+                    Character.toLowerCase(c1) != Character.toLowerCase(c2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Consider private.
+     *
+     * @deprecated Will be private in the next major version.
+     */
+    @Deprecated
+    public CharSequenceUtils() {
+        // empty
+    }
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/CharSequenceUtils.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/CharSequenceUtils.java
@@ -13,8 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
-package org.apache.commons.codec.binary;
+package com.jefftharris.commons.codec.binary;
 
 /**
  * <p>

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/CharSequenceUtils.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/CharSequenceUtils.java
@@ -29,6 +29,7 @@ package com.jefftharris.commons.codec.binary;
  * @see CharSequence
  * @since 1.10
  */
+@SuppressWarnings({"SameParameterValue", "GrazieStyle", "RedundantSuppression"})
 public class CharSequenceUtils {
 
     /**

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/Hex.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/Hex.java
@@ -13,19 +13,21 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec.binary;
+package com.jefftharris.commons.codec.binary;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.codec.BinaryDecoder;
-import org.apache.commons.codec.BinaryEncoder;
-import org.apache.commons.codec.CharEncoding;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.EncoderException;
+import com.jefftharris.commons.codec.BinaryDecoder;
+import com.jefftharris.commons.codec.BinaryEncoder;
+import com.jefftharris.commons.codec.CharEncoding;
+import com.jefftharris.commons.codec.DecoderException;
+import com.jefftharris.commons.codec.EncoderException;
 
 /**
  * Converts hexadecimal Strings. The Charset used for certain operation can be set, the default is set in

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/Hex.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/Hex.java
@@ -1,0 +1,566 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec.binary;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.codec.BinaryDecoder;
+import org.apache.commons.codec.BinaryEncoder;
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.EncoderException;
+
+/**
+ * Converts hexadecimal Strings. The Charset used for certain operation can be set, the default is set in
+ * {@link #DEFAULT_CHARSET_NAME}
+ *
+ * This class is thread-safe.
+ *
+ * @since 1.1
+ */
+public class Hex implements BinaryEncoder, BinaryDecoder {
+
+    /**
+     * Default charset is {@link StandardCharsets#UTF_8}.
+     *
+     * @since 1.7
+     */
+    public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+    /**
+     * Default charset name is {@link CharEncoding#UTF_8}.
+     *
+     * @since 1.4
+     */
+    public static final String DEFAULT_CHARSET_NAME = CharEncoding.UTF_8;
+
+    /**
+     * Used to build output as hex.
+     */
+    private static final char[] DIGITS_LOWER = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+
+    /**
+     * Used to build output as hex.
+     */
+    private static final char[] DIGITS_UPPER = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+
+    /**
+     * Converts an array of characters representing hexadecimal values into an array of bytes of those same values. The
+     * returned array will be half the length of the passed array, as it takes two characters to represent any given
+     * byte. An exception is thrown if the passed char array has an odd number of elements.
+     *
+     * @param data An array of characters containing hexadecimal digits.
+     * @return A byte array containing binary data decoded from the supplied char array.
+     * @throws DecoderException Thrown if an odd number of characters or illegal characters are supplied.
+     */
+    public static byte[] decodeHex(final char[] data) throws DecoderException {
+        final byte[] out = new byte[data.length >> 1];
+        decodeHex(data, out, 0);
+        return out;
+    }
+
+    /**
+     * Converts an array of characters representing hexadecimal values into an array of bytes of those same values. The
+     * returned array will be half the length of the passed array, as it takes two characters to represent any given
+     * byte. An exception is thrown if the passed char array has an odd number of elements.
+     *
+     * @param data An array of characters containing hexadecimal digits.
+     * @param out A byte array to contain the binary data decoded from the supplied char array.
+     * @param outOffset The position within {@code out} to start writing the decoded bytes.
+     * @return the number of bytes written to {@code out}.
+     * @throws DecoderException Thrown if an odd number of characters or illegal characters are supplied.
+     * @since 1.15
+     */
+    public static int decodeHex(final char[] data, final byte[] out, final int outOffset) throws DecoderException {
+        final int len = data.length;
+        if ((len & 1) != 0) {
+            throw new DecoderException("Odd number of characters %,d.", len);
+        }
+        final int outLen = len >> 1;
+        if (out.length - outOffset < outLen) {
+            throw new DecoderException("Output array is not large enough to accommodate decoded data.");
+        }
+        // two characters form the hex value.
+        for (int i = outOffset, j = 0; j < len; i++) {
+            int f = toDigit(data[j], j) << 4;
+            j++;
+            f |= toDigit(data[j], j);
+            j++;
+            out[i] = (byte) (f & 0xFF);
+        }
+        return outLen;
+    }
+
+    /**
+     * Converts a String representing hexadecimal values into an array of bytes of those same values. The returned array
+     * will be half the length of the passed String, as it takes two characters to represent any given byte. An
+     * exception is thrown if the passed String has an odd number of elements.
+     *
+     * @param data A String containing hexadecimal digits.
+     * @return A byte array containing binary data decoded from the supplied char array.
+     * @throws DecoderException Thrown if an odd number of characters or illegal characters are supplied.
+     * @since 1.11
+     */
+    public static byte[] decodeHex(final String data) throws DecoderException {
+        return decodeHex(data.toCharArray());
+    }
+
+    /**
+     * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.
+     * The returned array will be double the length of the passed array, as it takes two characters to represent any
+     * given byte.
+     *
+     * @param data a byte[] to convert to hexadecimal characters.
+     * @return A char[] containing lower-case hexadecimal characters.
+     */
+    public static char[] encodeHex(final byte[] data) {
+        return encodeHex(data, true);
+    }
+
+    /**
+     * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.
+     * The returned array will be double the length of the passed array, as it takes two characters to represent any
+     * given byte.
+     *
+     * @param data        a byte[] to convert to Hex characters.
+     * @param toLowerCase {@code true} converts to lowercase, {@code false} to uppercase.
+     * @return A char[] containing hexadecimal characters in the selected case.
+     * @since 1.4
+     */
+    public static char[] encodeHex(final byte[] data, final boolean toLowerCase) {
+        return encodeHex(data, toAlphabet(toLowerCase));
+    }
+
+    /**
+     * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.
+     * The returned array will be double the length of the passed array, as it takes two characters to represent any
+     * given byte.
+     *
+     * @param data     a byte[] to convert to hexadecimal characters.
+     * @param toDigits the output alphabet (must contain at least 16 chars).
+     * @return A char[] containing the appropriate characters from the alphabet For best results, this should be either
+     *         upper- or lower-case hex.
+     * @since 1.4
+     */
+    protected static char[] encodeHex(final byte[] data, final char[] toDigits) {
+        final int dataLength = data.length;
+        return encodeHex(data, 0, dataLength, toDigits, new char[dataLength << 1], 0);
+    }
+
+    /**
+     * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.
+     *
+     * @param data a byte[] to convert to hexadecimal characters.
+     * @param dataOffset the position in {@code data} to start encoding from.
+     * @param dataLen the number of bytes from {@code dataOffset} to encode.
+     * @param toLowerCase {@code true} converts to lowercase, {@code false} to uppercase.
+     * @return A char[] containing the appropriate characters from the alphabet For best results, this should be either
+     *         upper- or lower-case hex.
+     * @since 1.15
+     */
+    public static char[] encodeHex(final byte[] data, final int dataOffset, final int dataLen, final boolean toLowerCase) {
+        return encodeHex(data, dataOffset, dataLen, toAlphabet(toLowerCase), new char[dataLen << 1], 0);
+    }
+
+    /**
+     * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.
+     *
+     * @param data a byte[] to convert to hexadecimal characters.
+     * @param dataOffset the position in {@code data} to start encoding from.
+     * @param dataLen the number of bytes from {@code dataOffset} to encode.
+     * @param toLowerCase {@code true} converts to lowercase, {@code false} to uppercase.
+     * @param out a char[] which will hold the resultant appropriate characters from the alphabet.
+     * @param outOffset the position within {@code out} at which to start writing the encoded characters.
+     * @since 1.15
+     */
+    public static void encodeHex(final byte[] data, final int dataOffset, final int dataLen, final boolean toLowerCase, final char[] out, final int outOffset) {
+        encodeHex(data, dataOffset, dataLen, toAlphabet(toLowerCase), out, outOffset);
+    }
+
+    /**
+     * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.
+     *
+     * @param data a byte[] to convert to hexadecimal characters.
+     * @param dataOffset the position in {@code data} to start encoding from.
+     * @param dataLen the number of bytes from {@code dataOffset} to encode.
+     * @param toDigits the output alphabet (must contain at least 16 chars).
+     * @param out a char[] which will hold the resultant appropriate characters from the alphabet.
+     * @param outOffset the position within {@code out} at which to start writing the encoded characters.
+     * @return the given {@code out}.
+     */
+    private static char[] encodeHex(final byte[] data, final int dataOffset, final int dataLen, final char[] toDigits, final char[] out, final int outOffset) {
+        // two characters form the hex value.
+        for (int i = dataOffset, j = outOffset; i < dataOffset + dataLen; i++) {
+            out[j++] = toDigits[(0xF0 & data[i]) >>> 4];
+            out[j++] = toDigits[0x0F & data[i]];
+        }
+        return out;
+    }
+
+    /**
+     * Converts a byte buffer into an array of characters representing the hexadecimal values of each byte in order. The
+     * returned array will be double the length of the passed array, as it takes two characters to represent any given
+     * byte.
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
+     * @param data a byte buffer to convert to hexadecimal characters.
+     * @return A char[] containing lower-case hexadecimal characters.
+     * @since 1.11
+     */
+    public static char[] encodeHex(final ByteBuffer data) {
+        return encodeHex(data, true);
+    }
+
+    /**
+     * Converts a byte buffer into an array of characters representing the hexadecimal values of each byte in order. The
+     * returned array will be double the length of the passed array, as it takes two characters to represent any given
+     * byte.
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
+     * @param data        a byte buffer to convert to hexadecimal characters.
+     * @param toLowerCase {@code true} converts to lowercase, {@code false} to uppercase.
+     * @return A char[] containing hexadecimal characters in the selected case.
+     * @since 1.11
+     */
+    public static char[] encodeHex(final ByteBuffer data, final boolean toLowerCase) {
+        return encodeHex(data, toAlphabet(toLowerCase));
+    }
+
+    /**
+     * Converts a byte buffer into an array of characters representing the hexadecimal values of each byte in order. The
+     * returned array will be double the length of the passed array, as it takes two characters to represent any given
+     * byte.
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
+     * @param byteBuffer a byte buffer to convert to hexadecimal characters.
+     * @param toDigits   the output alphabet (must be at least 16 characters).
+     * @return A char[] containing the appropriate characters from the alphabet For best results, this should be either
+     *         upper- or lower-case hex.
+     * @since 1.11
+     */
+    protected static char[] encodeHex(final ByteBuffer byteBuffer, final char[] toDigits) {
+        return encodeHex(toByteArray(byteBuffer), toDigits);
+    }
+
+    /**
+     * Converts an array of bytes into a String representing the hexadecimal values of each byte in order. The returned
+     * String will be double the length of the passed array, as it takes two characters to represent any given byte.
+     *
+     * @param data a byte[] to convert to hexadecimal characters.
+     * @return A String containing lower-case hexadecimal characters.
+     * @since 1.4
+     */
+    public static String encodeHexString(final byte[] data) {
+        return new String(encodeHex(data));
+    }
+
+    /**
+     * Converts an array of bytes into a String representing the hexadecimal values of each byte in order. The returned
+     * String will be double the length of the passed array, as it takes two characters to represent any given byte.
+     *
+     * @param data        a byte[] to convert to hexadecimal characters.
+     * @param toLowerCase {@code true} converts to lowercase, {@code false} to uppercase.
+     * @return A String containing lower-case hexadecimal characters.
+     * @since 1.11
+     */
+    public static String encodeHexString(final byte[] data, final boolean toLowerCase) {
+        return new String(encodeHex(data, toLowerCase));
+    }
+
+    /**
+     * Converts a byte buffer into a String representing the hexadecimal values of each byte in order. The returned
+     * String will be double the length of the passed array, as it takes two characters to represent any given byte.
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
+     * @param data a byte buffer to convert to hexadecimal characters.
+     * @return A String containing lower-case hexadecimal characters.
+     * @since 1.11
+     */
+    public static String encodeHexString(final ByteBuffer data) {
+        return new String(encodeHex(data));
+    }
+
+    /**
+     * Converts a byte buffer into a String representing the hexadecimal values of each byte in order. The returned
+     * String will be double the length of the passed array, as it takes two characters to represent any given byte.
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
+     * @param data        a byte buffer to convert to hexadecimal characters.
+     * @param toLowerCase {@code true} converts to lowercase, {@code false} to uppercase.
+     * @return A String containing lower-case hexadecimal characters.
+     * @since 1.11
+     */
+    public static String encodeHexString(final ByteBuffer data, final boolean toLowerCase) {
+        return new String(encodeHex(data, toLowerCase));
+    }
+
+    /**
+     * Converts a boolean to an alphabet.
+     *
+     * @param toLowerCase true for lowercase, false for uppercase.
+     * @return an alphabet.
+     */
+    private static char[] toAlphabet(final boolean toLowerCase) {
+        return toLowerCase ? DIGITS_LOWER : DIGITS_UPPER;
+    }
+
+    /**
+     * Convert the byte buffer to a byte array. All bytes identified by
+     * {@link ByteBuffer#remaining()} will be used.
+     *
+     * @param byteBuffer the byte buffer.
+     * @return the byte[].
+     */
+    private static byte[] toByteArray(final ByteBuffer byteBuffer) {
+        final int remaining = byteBuffer.remaining();
+        // Use the underlying buffer if possible
+        if (byteBuffer.hasArray()) {
+            final byte[] byteArray = byteBuffer.array();
+            if (remaining == byteArray.length) {
+                byteBuffer.position(remaining);
+                return byteArray;
+            }
+        }
+        // Copy the bytes
+        final byte[] byteArray = new byte[remaining];
+        byteBuffer.get(byteArray);
+        return byteArray;
+    }
+
+    /**
+     * Converts a hexadecimal character to an integer.
+     *
+     * @param ch    A character to convert to an integer digit.
+     * @param index The index of the character in the source.
+     * @return An integer.
+     * @throws DecoderException Thrown if ch is an illegal hexadecimal character.
+     */
+    protected static int toDigit(final char ch, final int index) throws DecoderException {
+        final int digit = Character.digit(ch, 16);
+        if (digit == -1) {
+            throw new DecoderException("Illegal hexadecimal character 0x%02X at index %,d.", ch & 0xFF, index);
+        }
+        return digit;
+    }
+
+    private final Charset charset;
+
+    /**
+     * Creates a new codec with the default charset name {@link #DEFAULT_CHARSET}
+     */
+    public Hex() {
+        // use default encoding
+        this.charset = DEFAULT_CHARSET;
+    }
+
+    /**
+     * Creates a new codec with the given Charset.
+     *
+     * @param charset the charset.
+     * @since 1.7
+     */
+    public Hex(final Charset charset) {
+        this.charset = charset;
+    }
+
+    /**
+     * Creates a new codec with the given charset name.
+     *
+     * @param charsetName the charset name.
+     * @throws java.nio.charset.UnsupportedCharsetException If the named charset is unavailable.
+     * @since 1.4
+     * @since 1.7 throws UnsupportedCharsetException if the named charset is unavailable
+     */
+    public Hex(final String charsetName) {
+        this(Charset.forName(charsetName));
+    }
+
+    /**
+     * Converts an array of character bytes representing hexadecimal values into an array of bytes of those same values.
+     * The returned array will be half the length of the passed array, as it takes two characters to represent any given
+     * byte. An exception is thrown if the passed char array has an odd number of elements.
+     *
+     * @param array An array of character bytes containing hexadecimal digits.
+     * @return A byte array containing binary data decoded from the supplied byte array (representing characters).
+     * @throws DecoderException Thrown if an odd number of characters is supplied to this function.
+     * @see #decodeHex(char[])
+     */
+    @Override
+    public byte[] decode(final byte[] array) throws DecoderException {
+        return decodeHex(new String(array, getCharset()).toCharArray());
+    }
+
+    /**
+     * Converts a buffer of character bytes representing hexadecimal values into an array of bytes of those same values.
+     * The returned array will be half the length of the passed array, as it takes two characters to represent any given
+     * byte. An exception is thrown if the passed char array has an odd number of elements.
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
+     * @param buffer An array of character bytes containing hexadecimal digits.
+     * @return A byte array containing binary data decoded from the supplied byte array (representing characters).
+     * @throws DecoderException Thrown if an odd number of characters is supplied to this function.
+     * @see #decodeHex(char[])
+     * @since 1.11
+     */
+    public byte[] decode(final ByteBuffer buffer) throws DecoderException {
+        return decodeHex(new String(toByteArray(buffer), getCharset()).toCharArray());
+    }
+
+    /**
+     * Converts a String or an array of character bytes representing hexadecimal values into an array of bytes of those
+     * same values. The returned array will be half the length of the passed String or array, as it takes two characters
+     * to represent any given byte. An exception is thrown if the passed char array has an odd number of elements.
+     *
+     * @param object A String, ByteBuffer, byte[], or an array of character bytes containing hexadecimal digits.
+     * @return A byte array containing binary data decoded from the supplied byte array (representing characters).
+     * @throws DecoderException Thrown if an odd number of characters is supplied to this function or the object is not
+     *                          a String or char[].
+     * @see #decodeHex(char[])
+     */
+    @Override
+    public Object decode(final Object object) throws DecoderException {
+        if (object instanceof String) {
+            return decode(((String) object).toCharArray());
+        }
+        if (object instanceof byte[]) {
+            return decode((byte[]) object);
+        }
+        if (object instanceof ByteBuffer) {
+            return decode((ByteBuffer) object);
+        }
+        try {
+            return decodeHex((char[]) object);
+        } catch (final ClassCastException e) {
+            throw new DecoderException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Converts an array of bytes into an array of bytes for the characters representing the hexadecimal values of each
+     * byte in order. The returned array will be double the length of the passed array, as it takes two characters to
+     * represent any given byte.
+     * <p>
+     * The conversion from hexadecimal characters to the returned bytes is performed with the charset named by
+     * {@link #getCharset()}.
+     * </p>
+     *
+     * @param array a byte[] to convert to hexadecimal characters.
+     * @return A byte[] containing the bytes of the lower-case hexadecimal characters.
+     * @since 1.7 No longer throws IllegalStateException if the charsetName is invalid.
+     * @see #encodeHex(byte[])
+     */
+    @Override
+    public byte[] encode(final byte[] array) {
+        return encodeHexString(array).getBytes(getCharset());
+    }
+
+    /**
+     * Converts byte buffer into an array of bytes for the characters representing the hexadecimal values of each byte
+     * in order. The returned array will be double the length of the passed array, as it takes two characters to
+     * represent any given byte.
+     *
+     * <p>The conversion from hexadecimal characters to the returned bytes is performed with the charset named by
+     * {@link #getCharset()}.</p>
+     *
+     * <p>All bytes identified by {@link ByteBuffer#remaining()} will be used; after this method
+     * the value {@link ByteBuffer#remaining() remaining()} will be zero.</p>
+     *
+     * @param array a byte buffer to convert to hexadecimal characters.
+     * @return A byte[] containing the bytes of the lower-case hexadecimal characters.
+     * @see #encodeHex(byte[])
+     * @since 1.11
+     */
+    public byte[] encode(final ByteBuffer array) {
+        return encodeHexString(array).getBytes(getCharset());
+    }
+
+    /**
+     * Converts a String or an array of bytes into an array of characters representing the hexadecimal values of each
+     * byte in order. The returned array will be double the length of the passed String or array, as it takes two
+     * characters to represent any given byte.
+     * <p>
+     * The conversion from hexadecimal characters to bytes to be encoded to performed with the charset named by
+     * {@link #getCharset()}.
+     * </p>
+     *
+     * @param object a String, ByteBuffer, or byte[] to convert to hexadecimal characters.
+     * @return A char[] containing lower-case hexadecimal characters.
+     * @throws EncoderException Thrown if the given object is not a String or byte[].
+     * @see #encodeHex(byte[])
+     */
+    @Override
+    public Object encode(final Object object) throws EncoderException {
+        final byte[] byteArray;
+        if (object instanceof String) {
+            byteArray = ((String) object).getBytes(getCharset());
+        } else if (object instanceof ByteBuffer) {
+            byteArray = toByteArray((ByteBuffer) object);
+        } else {
+            try {
+                byteArray = (byte[]) object;
+            } catch (final ClassCastException e) {
+                throw new EncoderException(e.getMessage(), e);
+            }
+        }
+        return encodeHex(byteArray);
+    }
+
+    /**
+     * Gets the charset.
+     *
+     * @return the charset.
+     * @since 1.7
+     */
+    public Charset getCharset() {
+        return this.charset;
+    }
+
+    /**
+     * Gets the charset name.
+     *
+     * @return the charset name.
+     * @since 1.4
+     */
+    public String getCharsetName() {
+        return this.charset.name();
+    }
+
+    /**
+     * Returns a string representation of the object, which includes the charset name.
+     *
+     * @return a string representation of the object.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "[charsetName=" + this.charset + "]";
+    }
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/Hex.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/Hex.java
@@ -37,6 +37,8 @@ import com.jefftharris.commons.codec.EncoderException;
  *
  * @since 1.1
  */
+@SuppressWarnings(
+        {"WeakerAccess", "unused", "UnusedReturnValue", "NullableProblems"})
 public class Hex implements BinaryEncoder, BinaryDecoder {
 
     /**

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/StringUtils.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/StringUtils.java
@@ -1,0 +1,425 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.codec.binary;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.codec.CharEncoding;
+
+/**
+ * Converts String to and from bytes using the encodings required by the Java specification. These encodings are
+ * specified in standard {@link Charset}.
+ *
+ * <p>
+ * This class is immutable and thread-safe.
+ * </p>
+ *
+ * @see CharEncoding
+ * @see Charset
+ * @see StandardCharsets
+ * @since 1.4
+ */
+public class StringUtils {
+
+    /**
+     * <p>
+     * Compares two CharSequences, returning {@code true} if they represent equal sequences of characters.
+     * </p>
+     *
+     * <p>
+     * {@code null}s are handled without exceptions. Two {@code null} references are considered to be equal.
+     * The comparison is case sensitive.
+     * </p>
+     *
+     * <pre>
+     * StringUtils.equals(null, null)   = true
+     * StringUtils.equals(null, "abc")  = false
+     * StringUtils.equals("abc", null)  = false
+     * StringUtils.equals("abc", "abc") = true
+     * StringUtils.equals("abc", "ABC") = false
+     * </pre>
+     *
+     * <p>
+     * Copied from Apache Commons Lang r1583482 on April 10, 2014 (day of 3.3.2 release).
+     * </p>
+     *
+     * @see Object#equals(Object)
+     * @param cs1
+     *            the first CharSequence, may be {@code null}.
+     * @param cs2
+     *            the second CharSequence, may be {@code null}.
+     * @return {@code true} if the CharSequences are equal (case-sensitive), or both {@code null}.
+     * @since 1.10
+     */
+    public static boolean equals(final CharSequence cs1, final CharSequence cs2) {
+        if (cs1 == cs2) {
+            return true;
+        }
+        if (cs1 == null || cs2 == null) {
+            return false;
+        }
+        if (cs1 instanceof String && cs2 instanceof String) {
+            return cs1.equals(cs2);
+        }
+        return cs1.length() == cs2.length() && CharSequenceUtils.regionMatches(cs1, false, 0, cs2, 0, cs1.length());
+    }
+
+    /**
+     * Calls {@link String#getBytes(Charset)}
+     *
+     * @param string
+     *            The string to encode (if null, return null).
+     * @param charset
+     *            The {@link Charset} to encode the {@code String}.
+     * @return the encoded bytes.
+     */
+    private static ByteBuffer getByteBuffer(final String string, final Charset charset) {
+        if (string == null) {
+            return null;
+        }
+        return ByteBuffer.wrap(string.getBytes(charset));
+    }
+
+    /**
+     * Encodes the given string into a byte buffer using the UTF-8 charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be {@code null}.
+     * @return encoded bytes, or {@code null} if the input string was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#UTF_8} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @see Charset
+     * @see #getBytesUnchecked(String, String)
+     * @since 1.11
+     */
+    public static ByteBuffer getByteBufferUtf8(final String string) {
+        return getByteBuffer(string, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Calls {@link String#getBytes(Charset)}
+     *
+     * @param string
+     *            The string to encode (if null, return null).
+     * @param charset
+     *            The {@link Charset} to encode the {@code String}.
+     * @return the encoded bytes.
+     */
+    private static byte[] getBytes(final String string, final Charset charset) {
+        return string == null ? null : string.getBytes(charset);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the ISO-8859-1 charset, storing the result into a new
+     * byte array.
+     *
+     * @param string
+     *            the String to encode, may be {@code null}.
+     * @return encoded bytes, or {@code null} if the input string was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#ISO_8859_1} is not initialized, which should never happen
+     *             since it is required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     * @see Charset
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesIso8859_1(final String string) {
+        return getBytes(string, StandardCharsets.ISO_8859_1);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the named charset, storing the result into a new byte
+     * array.
+     * <p>
+     * This method catches {@link UnsupportedEncodingException} and rethrows it as {@link IllegalStateException}, which
+     * should never happen for a required charset name. Use this method when the encoding is required to be in the JRE.
+     * </p>
+     *
+     * @param string
+     *            the String to encode, may be {@code null}.
+     * @param charsetName
+     *            The name of a required {@link java.nio.charset.Charset}.
+     * @return encoded bytes, or {@code null} if the input string was {@code null}.
+     * @throws IllegalStateException
+     *             Thrown when a {@link UnsupportedEncodingException} is caught, which should never happen for a
+     *             required charset name.
+     * @see CharEncoding
+     * @see String#getBytes(String)
+     */
+    public static byte[] getBytesUnchecked(final String string, final String charsetName) {
+        if (string == null) {
+            return null;
+        }
+        try {
+            return string.getBytes(charsetName);
+        } catch (final UnsupportedEncodingException e) {
+            throw newIllegalStateException(charsetName, e);
+        }
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the US-ASCII charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be {@code null}.
+     * @return encoded bytes, or {@code null} if the input string was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#US_ASCII} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     * @see Charset
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUsAscii(final String string) {
+        return getBytes(string, StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the UTF-16 charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be {@code null}.
+     * @return encoded bytes, or {@code null} if the input string was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#UTF_16} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     * @see Charset
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUtf16(final String string) {
+        return getBytes(string, StandardCharsets.UTF_16);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the UTF-16BE charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be {@code null}.
+     * @return encoded bytes, or {@code null} if the input string was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#UTF_16BE} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     * @see Charset
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUtf16Be(final String string) {
+        return getBytes(string, StandardCharsets.UTF_16BE);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the UTF-16LE charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be {@code null}.
+     * @return encoded bytes, or {@code null} if the input string was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#UTF_16LE} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     * @see Charset
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUtf16Le(final String string) {
+        return getBytes(string, StandardCharsets.UTF_16LE);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the UTF-8 charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be {@code null}.
+     * @return encoded bytes, or {@code null} if the input string was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#UTF_8} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     * @see Charset
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUtf8(final String string) {
+        return getBytes(string, StandardCharsets.UTF_8);
+    }
+
+    private static IllegalStateException newIllegalStateException(final String charsetName, final UnsupportedEncodingException e) {
+        return new IllegalStateException(charsetName + ": " + e);
+    }
+
+    /**
+     * Constructs a new {@code String} by decoding the specified array of bytes using the given charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters.
+     * @param charset
+     *            The {@link Charset} to encode the {@code String}; not {@code null}.
+     * @return A new {@code String} decoded from the specified array of bytes using the given charset,
+     *         or {@code null} if the input byte array was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if charset is {@code null}.
+     */
+    private static String newString(final byte[] bytes, final Charset charset) {
+        return bytes == null ? null : new String(bytes, charset);
+    }
+
+    /**
+     * Constructs a new {@code String} by decoding the specified array of bytes using the given charset.
+     * <p>
+     * This method catches {@link UnsupportedEncodingException} and re-throws it as {@link IllegalStateException}, which
+     * should never happen for a required charset name. Use this method when the encoding is required to be in the JRE.
+     * </p>
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters, may be {@code null}.
+     * @param charsetName
+     *            The name of a required {@link java.nio.charset.Charset}.
+     * @return A new {@code String} decoded from the specified array of bytes using the given charset,
+     *         or {@code null} if the input byte array was {@code null}.
+     * @throws IllegalStateException
+     *             Thrown when a {@link UnsupportedEncodingException} is caught, which should never happen for a
+     *             required charset name.
+     * @see CharEncoding
+     * @see String#String(byte[], String)
+     */
+    public static String newString(final byte[] bytes, final String charsetName) {
+        if (bytes == null) {
+            return null;
+        }
+        try {
+            return new String(bytes, charsetName);
+        } catch (final UnsupportedEncodingException e) {
+            throw newIllegalStateException(charsetName, e);
+        }
+    }
+
+    /**
+     * Constructs a new {@code String} by decoding the specified array of bytes using the ISO-8859-1 charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters, may be {@code null}.
+     * @return A new {@code String} decoded from the specified array of bytes using the ISO-8859-1 charset, or
+     *         {@code null} if the input byte array was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#ISO_8859_1} is not initialized, which should never happen
+     *             since it is required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     */
+    public static String newStringIso8859_1(final byte[] bytes) {
+        return newString(bytes, StandardCharsets.ISO_8859_1);
+    }
+
+    /**
+     * Constructs a new {@code String} by decoding the specified array of bytes using the US-ASCII charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters.
+     * @return A new {@code String} decoded from the specified array of bytes using the US-ASCII charset,
+     *         or {@code null} if the input byte array was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#US_ASCII} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     */
+    public static String newStringUsAscii(final byte[] bytes) {
+        return newString(bytes, StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Constructs a new {@code String} by decoding the specified array of bytes using the UTF-16 charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters.
+     * @return A new {@code String} decoded from the specified array of bytes using the UTF-16 charset
+     *         or {@code null} if the input byte array was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#UTF_16} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     */
+    public static String newStringUtf16(final byte[] bytes) {
+        return newString(bytes, StandardCharsets.UTF_16);
+    }
+
+    /**
+     * Constructs a new {@code String} by decoding the specified array of bytes using the UTF-16BE charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters.
+     * @return A new {@code String} decoded from the specified array of bytes using the UTF-16BE charset,
+     *         or {@code null} if the input byte array was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#UTF_16BE} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     */
+    public static String newStringUtf16Be(final byte[] bytes) {
+        return newString(bytes, StandardCharsets.UTF_16BE);
+    }
+
+    /**
+     * Constructs a new {@code String} by decoding the specified array of bytes using the UTF-16LE charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters.
+     * @return A new {@code String} decoded from the specified array of bytes using the UTF-16LE charset,
+     *         or {@code null} if the input byte array was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#UTF_16LE} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     */
+    public static String newStringUtf16Le(final byte[] bytes) {
+        return newString(bytes, StandardCharsets.UTF_16LE);
+    }
+
+    /**
+     * Constructs a new {@code String} by decoding the specified array of bytes using the UTF-8 charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters.
+     * @return A new {@code String} decoded from the specified array of bytes using the UTF-8 charset,
+     *         or {@code null} if the input byte array was {@code null}.
+     * @throws NullPointerException
+     *             Thrown if {@link StandardCharsets#UTF_8} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException.
+     */
+    public static String newStringUtf8(final byte[] bytes) {
+        return newString(bytes, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * TODO Make private in 2.0.
+     *
+     * @deprecated TODO Make private in 2.0.
+     */
+    @Deprecated
+    public StringUtils() {
+        // empty
+    }
+}

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/StringUtils.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/StringUtils.java
@@ -39,6 +39,9 @@ import com.jefftharris.commons.codec.CharEncoding;
  * @see StandardCharsets
  * @since 1.4
  */
+@SuppressWarnings(
+        {"SameParameterValue", "ReturnOfNull", "unused", "WeakerAccess",
+         "SpellCheckingInspection", "GrazieInspection", "RedundantSuppression"})
 public class StringUtils {
 
     /**
@@ -416,9 +419,9 @@ public class StringUtils {
     }
 
     /**
-     * TODO Make private in 2.0.
+     * TODOapache Make private in 2.0.
      *
-     * @deprecated TODO Make private in 2.0.
+     * @deprecated TODOapache Make private in 2.0.
      */
     @Deprecated
     public StringUtils() {

--- a/lib/src/main/java/com/jefftharris/commons/codec/binary/StringUtils.java
+++ b/lib/src/main/java/com/jefftharris/commons/codec/binary/StringUtils.java
@@ -13,16 +13,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Package renamed for inclusion in PasswdSafe project
  */
 
-package org.apache.commons.codec.binary;
+package com.jefftharris.commons.codec.binary;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.codec.CharEncoding;
+import com.jefftharris.commons.codec.CharEncoding;
 
 /**
  * Converts String to and from bytes using the encodings required by the Java specification. These encodings are

--- a/passwdsafe/build.gradle
+++ b/passwdsafe/build.gradle
@@ -98,8 +98,6 @@ dependencies {
 
     annotationProcessor "androidx.room:room-compiler:$room_version"
 
-    implementation 'commons-codec:commons-codec:1.21.0'
-
     // Core library
     androidTestImplementation 'androidx.test:core:1.7.0'
 

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/AboutFragment.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/AboutFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2025 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -80,7 +80,8 @@ public class AboutFragment extends Fragment
 
         String licenses = AboutUtils.getLicenses(
                 requireContext(), "license-PasswdSafe.txt",
-                "license-android.txt", "license-AndroidAssetStudio.txt",
+                "license-android.txt", "license-apache.txt",
+                "license-AndroidAssetStudio.txt",
                 "license-MaterialIcons.txt", "license-icons.txt",
                 "license-RobotoMono.txt");
 

--- a/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/Totp.java
+++ b/passwdsafe/src/main/java/com/jefftharris/passwdsafe/file/Totp.java
@@ -11,12 +11,12 @@ import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.jefftharris.commons.codec.CodecPolicy;
+import com.jefftharris.commons.codec.DecoderException;
+import com.jefftharris.commons.codec.binary.Hex;
+import com.jefftharris.commons.codec.binary.Base32;
 import com.jefftharris.passwdsafe.util.Pair;
 
-import org.apache.commons.codec.CodecPolicy;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.binary.Base32;
-import org.apache.commons.codec.binary.Hex;
 import org.jetbrains.annotations.Contract;
 import org.pwsafe.lib.Util;
 import org.pwsafe.lib.file.Owner;

--- a/sync/src/main/java/com/jefftharris/passwdsafe/sync/AboutDialog.java
+++ b/sync/src/main/java/com/jefftharris/passwdsafe/sync/AboutDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (©) 2016-2024 Jeff Harris <jefftharris@gmail.com>
+ * Copyright (©) 2016-2026 Jeff Harris <jefftharris@gmail.com>
  * All rights reserved. Use of the code is allowed under the
  * Artistic License 2.0 terms, as specified in the LICENSE file
  * distributed with this code, or available from
@@ -22,12 +22,13 @@ import androidx.appcompat.app.AppCompatDialogFragment;
 import com.jefftharris.passwdsafe.lib.AboutUtils;
 
 /**
- *  The about dialog
+ * Dialog for showing app 'about' information
  */
 public class AboutDialog extends AppCompatDialogFragment
         implements DialogInterface.OnClickListener
 {
     /** Create a new instance */
+    @NonNull
     public static AboutDialog newInstance()
     {
         AboutDialog frag = new AboutDialog();
@@ -51,7 +52,8 @@ public class AboutDialog extends AppCompatDialogFragment
 
         String licenses = AboutUtils.getLicenses(
                 requireContext(), "license-PasswdSafe.txt",
-                "license-android.txt", "license-AndroidAssetStudio.txt",
+                "license-android.txt", "license-apache.txt",
+                "license-AndroidAssetStudio.txt",
                 "license-MaterialIcons.txt", "license-icons.txt",
                 "license-box.txt", "license-onedrive.txt");
         String name = AboutUtils.updateAboutFields(detailsView, licenses, act);


### PR DESCRIPTION
Use the local renamed copy of commons-codec to avoid complications with an older
version of the library used by older Android app launchers.

Addresses: #14 